### PR TITLE
Analysis Page Demo

### DIFF
--- a/app/panels/PanelAnalysis.js
+++ b/app/panels/PanelAnalysis.js
@@ -1,0 +1,75 @@
+const Panel = require(path.join(ROOT, 'app/js/Panel.js'));
+
+module.exports = class PanelAnalysis extends Panel {
+
+    /*
+    A demo function for fancy features
+    */
+    doSpecialStuff() {
+
+        let elem = document.getElementById('woo_flashing_html');
+
+        if (elem !== null) {
+            if (this.someSpecialVar) {
+                document.getElementById('woo_flashing_html').style.backgroundColor = "red";
+
+            } else {
+                document.getElementById('woo_flashing_html').style.backgroundColor = "green";
+            }
+        }
+
+        this.someSpecialVar = !this.someSpecialVar;
+
+        setInterval(this.doSpecialStuff, 500);
+    }
+
+    constructor(guiKey) {
+        super();
+        this._guiKey = guiKey;
+
+        const Utils = require(path.join(ROOT, 'app/js/utils.js'));
+
+        let html = Utils.read(path.join(ROOT, 'app/panels/analysis.html'));
+        this.getRootElement().innerHTML = html;
+
+        this.someSpecialVar = 1;
+        this.doSpecialStuff();
+    }
+
+    loadGUI(state) {
+        console.error("loadGUI() Not implemented in PanelAnalysis.js");
+
+        if (!state.hasOwnProperty(this._guiKey)) {
+            console.error(`Could not find ${this._guiKey} in ${state}`);
+            return false;
+        } else {
+            let data = state[this._guiKey];
+            // More code here...
+        }
+    }
+
+    getState() {
+        let data = {};
+        console.error("getState() Not implemented in PanelAnalysis.js");
+        // More code here...
+        return data;
+    }
+
+    setState(state) {
+        console.error("setState() Not implemented in PanelAnalysis.js")
+
+        if (!state.hasOwnProperty(this._guiKey)) {
+            console.error(`Could not find ${this._guiKey} in ${state}`);
+            return false;
+        }
+
+        let items = state[this._guiKey];
+
+        // More code here...
+
+        return true;
+
+    }
+
+
+};

--- a/app/panels/analysis.html
+++ b/app/panels/analysis.html
@@ -1,0 +1,29 @@
+<div>
+    <h2 id='woo_flashing_html'>Analysis page</h2>
+</div>
+
+<script>
+    // This code does not get executed when injected.
+    // Would need some hacks.
+    // Instead implement panel specific features in PanelAnalysis.js
+    // jQuery also does not seem to work by default
+    
+    var someGlobal = 1;
+
+    function doSpecialStuff() {
+
+        if (someGlobal) {
+            document.getElementById('woo_flashing_html').style.backgroundColor = "red";
+        } else {
+            document.getElementById('woo_flashing_html').style.backgroundColor = "red";
+        }
+
+        console.log('tick');
+        someGlobal = !someGlobal;
+
+        setInterval(doSpecialStuff, 500);
+    }
+    console.log('tick2');
+    doSpecialStuff();
+
+</script>

--- a/app/panels/index.html
+++ b/app/panels/index.html
@@ -15,13 +15,14 @@
       <ul class="tabs">
         <li class="tab col s3"><a class="active" href="#details">Details</a></li>
         <li class="tab col s3"><a href="#assessments">Assessments</a></li>
+        <li class="tab col s3"><a href="#analysis">Analysis</a></li>
       </ul>
     </div>
 
     <div id="details" class="col s12">
         <p>details...</p>
         <div id='test_inject'></div>
-        
+
     </div>
 
     <div id="assessments" class="col s12" style="display: none">
@@ -51,7 +52,10 @@
           <div id="tab_people_orientation" class="col s12 card"></div>
           <div id="tab_spoken_words" class="col s12"></div>
 
+      </div>
     </div>
+
+    <div id="analysis" class="col s12" style="display: none"></div>
 
     </div>
   </div>

--- a/app/panels/index.js
+++ b/app/panels/index.js
@@ -42,6 +42,7 @@ injectPanel(JS_PATH + '/PanelQuestions.js', 'tab_passions', 'Passions');
 injectPanel(JS_PATH + '/PanelQuestions.js', 'tab_people_id', 'People_ID');
 injectPanel(JS_PATH + '/PanelQuestions.js', 'tab_values', 'Values');
 injectPanel(PANEL_PATH + '/PanelSpokenWords.js', 'tab_spoken_words', 'Spoken_Words');
+injectPanel(PANEL_PATH + '/PanelAnalysis.js', 'analysis', 'Analysis');
 
 dataManager.loadGUI();
 dataManager.loadUserData();


### PR DESCRIPTION
The easiest way to implement panel specific features is to extent the base `Panel` class and implement features that way. This demo for the analysis page creates a new panel with some fancy panel specific features. The layout of the page is defined in the `analysis.html` file, which is injected when the panel is created in `index.js`.

#### Notes:
- Javascript that is injected is not executed by default.
- jQuery does not work by default
- The extended panel has to implement the base pane functions

----

### Added
- Analysis tab
- An example page using a Panel and some page specific Javascript