### PR TITLE
Add extra compiler flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CXX=g++
 CXX_WIN=i686-w64-mingw32-g++
-CXXFLAGS=-std=c++11 -g -I.
+CXXFLAGS=-std=c++11 -g -I. -Werror -Wall -pedantic
 SOURCE_FILES=src/data_manager.cpp src/main_frame.cpp src/prothesis_app.cpp \
 src/data_panel.cpp
 WIN_WX_STATIC_CONFIG=.win_wx_static_config


### PR DESCRIPTION
Added the flags `-Werror -Wall -pedantic`

You will now receive an error when building for windows:
```
i686-w64-mingw32-g++ src/data_manager.cpp src/main_frame.cpp src/prothesis_app.cpp src/data_panel.cpp -std=c++11 -g -I. -Werror -Wall -pedantic --static \
`/home/evert/wxWidgets-3.0.3/msw-static/wx-config --libs --cxxflags` -o build/prothesis-2.exe
In file included from /home/evert/wxWidgets-3.0.3/include/wx/utils.h:20:0,
                 from /home/evert/wxWidgets-3.0.3/include/wx/cursor.h:69,
                 from /home/evert/wxWidgets-3.0.3/include/wx/event.h:21,
                 from /home/evert/wxWidgets-3.0.3/include/wx/wx.h:24,
                 from src/main_frame.hpp:6,
                 from src/main_frame.cpp:1:
/home/evert/wxWidgets-3.0.3/include/wx/filefn.h:220:74: error: extra ‘;’ [-Werror=pedantic]
         wxDECL_FOR_STRICT_MINGW32(int, fseeko64, (FILE*, long long, int));
```

This can be fixed by editing `.../wxWidgets-3.0.3/include/wx/filefn.h:220:74` and removing the extra semicolon.