### PR TITLE
Makefile Improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,22 +4,13 @@ WINDRES=i686-w64-mingw32-windres
 
 CXXFLAGS=-std=c++11 -g -I. -Werror -Wall -pedantic
 
-SOURCE_FILES=src/data_manager.cpp src/main_frame.cpp src/prothesis_app.cpp \
-src/panels/details_panel.cpp src/data_panel.cpp src/utilities.cpp \
-src/paged_panel.cpp src/questions_panel.cpp
+SOURCE_FILES=$(shell find -name '*.cpp' | sed 's/\.\///g')
+OBJECT_FILES_LINUX=${SOURCE_FILES:src/%.cpp=build/linux/%.o}
 
-OBJECT_FILES_LINUX=build/linux/data_manager.o build/linux/main_frame.o \
-build/linux/prothesis_app.o build/linux/details_panel.o \
-build/linux/data_panel.o build/linux/utilities.o \
-build/linux/paged_panel.o build/linux/questions_panel.o
-
-OBJECT_FILES_WINDOWS=build/windows/data_manager.o build/windows/main_frame.o \
-build/windows/prothesis_app.o build/windows/details_panel.o \
-build/windows/data_panel.o build/windows/utilities.o \
-build/windows/paged_panel.o build/windows/questions_panel.o
+OBJECT_FILES_WINDOWS=${SOURCE_FILES:src/%.cpp=build/windows/%.o}
+RESOURCE_FILE=src/resources.rc
 
 WX_CONFIG_LINUX=`wx-config --toolkit=gtk2 --libs --cxxflags`
-RESOURCE_FILE=src/resources.rc
 
 WIN_WX_STATIC_CONFIG=.win_wx_static_config
 
@@ -32,54 +23,29 @@ WX_CONFIG_WINDOWS_LINK = `${WX_PATH}/wx-config --libs`
 all: linux windows
 	@echo "Build done for Linux and Windows"
 
-build_dir:
+##############################################
+# COMMON
+############
+
+apply_gui_config:
 	mkdir -p build
-
-apply_gui_config: build_dir
 	cp gui.toml build/
-
-windows_build_dir:
-	mkdir -p build/windows
-
-linux_build_dir:
-	mkdir -p build/linux
 
 lint:
 	./lint.sh
 
-build/linux/data_manager.o: src/data_manager.cpp
-	${CXX} ${CXXFLAGS} ${WX_CONFIG_LINUX} -c src/data_manager.cpp \
-	-o build/linux/data_manager.o
+clean:
+	rm -fr build/
 
-build/linux/main_frame.o: src/main_frame.cpp
-	${CXX} ${CXXFLAGS} ${WX_CONFIG_LINUX} -c src/main_frame.cpp \
-	-o build/linux/main_frame.o
+############################################
+# LINUX
+####################
+build/linux/%.o: src/%.cpp
+	@mkdir -p $(@D)
+	${CXX} ${CXXFLAGS} ${WX_CONFIG_LINUX} -c $< -o $@
 
-build/linux/prothesis_app.o: src/prothesis_app.cpp
-	${CXX} ${CXXFLAGS} ${WX_CONFIG_LINUX} -c src/prothesis_app.cpp \
-	-o build/linux/prothesis_app.o
-
-build/linux/details_panel.o: src/panels/details_panel.cpp
-	${CXX} ${CXXFLAGS} ${WX_CONFIG_LINUX} -c src/panels/details_panel.cpp \
-	-o build/linux/details_panel.o
-
-build/linux/data_panel.o: src/data_panel.cpp
-	${CXX} ${CXXFLAGS} ${WX_CONFIG_LINUX} -c src/data_panel.cpp \
-	-o build/linux/data_panel.o
-
-build/linux/utilities.o: src/utilities.cpp
-	${CXX} ${CXXFLAGS} -c src/utilities.cpp \
-	-o build/linux/utilities.o
-
-build/linux/paged_panel.o: src/paged_panel.cpp
-	${CXX} ${CXXFLAGS} ${WX_CONFIG_LINUX} -c src/paged_panel.cpp \
-	-o build/linux/paged_panel.o
-
-build/linux/questions_panel.o: src/questions_panel.cpp
-	${CXX} ${CXXFLAGS} ${WX_CONFIG_LINUX} -c src/questions_panel.cpp \
-	-o build/linux/questions_panel.o
-
-linux: linux_build_dir lint apply_gui_config ${OBJECT_FILES_LINUX}
+linux: lint apply_gui_config ${OBJECT_FILES_LINUX}
+	@echo ${SOURCE_FILES}
 	mkdir -p build
 	${CXX} ${OBJECT_FILES_LINUX} ${CXXFLAGS} ${WX_CONFIG_LINUX} \
 	-o build/prothesis-2
@@ -88,43 +54,15 @@ linux: linux_build_dir lint apply_gui_config ${OBJECT_FILES_LINUX}
 # WINDOWS
 #########################
 
-build/windows/data_manager.o: src/data_manager.cpp
-	${CXX_WIN} ${CXXFLAGS} ${WX_CONFIG_WINDOWS} -c src/data_manager.cpp \
-	-o build/windows/data_manager.o
-
-build/windows/main_frame.o: src/main_frame.cpp
-	${CXX_WIN} ${CXXFLAGS} ${WX_CONFIG_WINDOWS} -c src/main_frame.cpp \
-	-o build/windows/main_frame.o
-
-build/windows/prothesis_app.o: src/prothesis_app.cpp
-	${CXX_WIN} ${CXXFLAGS} ${WX_CONFIG_WINDOWS} -c src/prothesis_app.cpp \
-	-o build/windows/prothesis_app.o
-
-build/windows/details_panel.o: src/panels/details_panel.cpp
-	${CXX_WIN} ${CXXFLAGS} ${WX_CONFIG_WINDOWS} -c src/panels/details_panel.cpp \
-	-o build/windows/details_panel.o
-
-build/windows/data_panel.o: src/data_panel.cpp
-	${CXX_WIN} ${CXXFLAGS} ${WX_CONFIG_WINDOWS} -c src/data_panel.cpp \
-	-o build/windows/data_panel.o
-
-build/windows/utilities.o: src/utilities.cpp
-	${CXX_WIN} ${CXXFLAGS} -c src/utilities.cpp \
-	-o build/windows/utilities.o
-
-build/windows/paged_panel.o: src/paged_panel.cpp
-	${CXX_WIN} ${CXXFLAGS} ${WX_CONFIG_WINDOWS} -c src/paged_panel.cpp \
-	-o build/windows/paged_panel.o
-
-build/windows/questions_panel.o: src/questions_panel.cpp
-	${CXX_WIN} ${CXXFLAGS} ${WX_CONFIG_WINDOWS} -c src/questions_panel.cpp \
-	-o build/windows/questions_panel.o
+build/windows/%.o: src/%.cpp
+	@mkdir -p $(@D)
+	${CXX_WIN} ${CXXFLAGS} ${WX_CONFIG_WINDOWS} -c $< -o $@
 
 build/resources.o: ${RESOURCE_FILE}
 	mkdir -p build
 	${WINDRES} ${RESOURCE_FILE} -I${WX_PATH}/../include -o build/resources.o
 
-windows: windows_build_dir lint apply_gui_config ${SOURCE_FILES} build/resources.o ${OBJECT_FILES_WINDOWS}
+windows: lint apply_gui_config ${SOURCE_FILES} build/resources.o ${OBJECT_FILES_WINDOWS}
 ifneq (${WX_PATH}, )
 	mkdir -p build
 	${CXX_WIN} ${CXXFLAGS} ${OBJECT_FILES_WINDOWS} ${WX_CONFIG_WINDOWS_LINK} --static \
@@ -133,6 +71,3 @@ else
 	@echo "Please add the path to the statically compiled wxWidgets \
 	to the file '.win_wx_static_config'"
 endif
-
-clean:
-	rm -fr build/


### PR DESCRIPTION
- Simplify Makefile from 104 sloc to 56 sloc
- Find source files using `find`
  - Source files no loner need to be manually added to Makefile
- Implicit build rules

Suggested by @devosray 