### PR TITLE
Navigation Drawer

### DIFF
--- a/src/data_manager.cpp
+++ b/src/data_manager.cpp
@@ -127,7 +127,6 @@ void DataManager::SaveUserConfig() {
 
     std::stringstream output;
     output << *user_config;
-    wxLogDebug(_("User data = \n") + _(output.str().c_str()));
     wxLogDebug("Writing User config...");
 
     std::fstream fs(user_config_path_, std::fstream::out);

--- a/src/data_manager.hpp
+++ b/src/data_manager.hpp
@@ -38,7 +38,8 @@ class DataManager {
     kDreamsPanel = 3,
     kValuesPanel = 4,
     kSpokenWordsPanel = 5,
-    kPanelCount = 6
+    kPanelCount = 6,
+    kDefaultPanel = -1
   };
 
   /**

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -2,6 +2,8 @@
 #include <csignal>
 #include <string>
 
+#include "navigation_drawer.hpp"
+
 void MainFrame::OnKill(int sig) {
   wxLogDebug("MainFrame::OnKill");
   wxExit();
@@ -71,8 +73,10 @@ void MainFrame::OnClose(wxCloseEvent &e) {
 }
 
 void MainFrame::DisplayPanelById(DataManager::PanelId id) {
-  DisplayPanel(data_manager_->GetPanelById(id));
-  active_panel_id_ = id;
+  if (active_panel_id_ != id) {
+    DisplayPanel(data_manager_->GetPanelById(id));
+    active_panel_id_ = id;
+  }
 }
 
 // TODO(egeldenhuys): This is a bad implementation. Should be
@@ -164,7 +168,8 @@ void MainFrame::DoLayout() {
   sizer_main_frame_master_->Add(sizer_bar, 1, wxEXPAND, 0);
 
   // sizer_content_
-  sizer_content_->Add(0, 0, 0, 0, 0);
+  NavigationDrawer *drawer = new NavigationDrawer(this, wxID_ANY);
+  sizer_content_->Add(drawer, 0, 0, 0, 0);
   sizer_content_->Add(0, 0, 0, 0, 0);
   sizer_content_->Add(0, 0, 0, 0, 0);
   sizer_content_->AddGrowableCol(0);

--- a/src/navigation_drawer.cpp
+++ b/src/navigation_drawer.cpp
@@ -1,0 +1,44 @@
+#include "navigation_drawer.hpp"
+
+#include <string>
+
+NavigationDrawer::NavigationDrawer(wxWindow* parent,
+                                   wxWindowID id,
+                                   const wxPoint& pos,
+                                   const wxSize& size,
+                                   int64_t style)
+  : wxPanel(parent, id, pos, size, style) {
+  sizer_ = new wxGridSizer(0, 1, 0, 0);
+  SetProperties();
+  DoLayout();
+}
+
+void NavigationDrawer::SetProperties() {
+  // void
+}
+
+void NavigationDrawer::OnItemClick(wxCommandEvent &event) {
+  NavigationItem *item = static_cast<NavigationItem*>(event.GetEventObject());
+  MainFrame *main_frame = static_cast<MainFrame*>(wxTheApp->GetTopWindow());
+
+  main_frame->DisplayPanelById(item->GetTarget());
+}
+
+void NavigationDrawer::AddItem(std::string label, DataManager::PanelId target) {
+  NavigationItem *btn = new NavigationItem(this, wxID_ANY, _(label), target);
+  sizer_->Add(btn, 1, wxEXPAND, 0);
+  btn->Bind(wxEVT_BUTTON, &NavigationDrawer::OnItemClick, this);
+}
+
+void NavigationDrawer::DoLayout() {
+  wxLogDebug("NavigationDrawer::DoLayout() START");
+  AddItem("Details", DataManager::PanelId::kDetailsPanel);
+  AddItem("Passions", DataManager::PanelId::kPassionPanel);
+  AddItem("Dreams", DataManager::PanelId::kDreamsPanel);
+  AddItem("People ID", DataManager::PanelId::kPeopleIdPanel);
+  AddItem("Values", DataManager::PanelId::kValuesPanel);
+  AddItem("Spoken Words", DataManager::PanelId::kSpokenWordsPanel);
+  this->SetSizer(sizer_);
+  Layout();
+  wxLogDebug("NavigationDrawer::DoLayout() END");
+}

--- a/src/navigation_drawer.hpp
+++ b/src/navigation_drawer.hpp
@@ -1,0 +1,31 @@
+#ifndef NAVIGATION_DRAWER_HPP_
+#define NAVIGATION_DRAWER_HPP_
+
+#include <wx/wxprec.h>
+#ifndef WX_PRECOMP
+    #include <wx/wx.h>
+#endif
+
+#include <string>
+
+#include "data_manager.hpp"
+#include "navigation_item.hpp"
+#include "main_frame.hpp"
+
+class NavigationDrawer : public wxPanel {
+ public:
+  NavigationDrawer(wxWindow* parent,
+                   wxWindowID id,
+                   const wxPoint& pos = wxDefaultPosition,
+                   const wxSize& size = wxDefaultSize,
+                   int64_t style = 0);
+
+ private:
+  void AddItem(std::string label, DataManager::PanelId);
+  void OnItemClick(wxCommandEvent &event);  // NOLINT
+  void SetProperties();
+  void DoLayout();
+  wxGridSizer *sizer_ = NULL;
+};
+
+#endif  // NAVIGATION_DRAWER_HPP_

--- a/src/navigation_item.cpp
+++ b/src/navigation_item.cpp
@@ -1,0 +1,17 @@
+#include "navigation_item.hpp"
+#include <string>
+
+NavigationItem::NavigationItem(wxWindow *parent,
+                               wxWindowID id,
+                               const wxString &label,
+                               const DataManager::PanelId target,
+                               const wxPoint &pos,
+                               const wxSize &size,
+                               int64_t style)
+  : wxButton(parent, id, label, pos, size, style) {
+  target_ = target;
+}
+
+DataManager::PanelId NavigationItem::GetTarget() {
+  return target_;
+}

--- a/src/navigation_item.hpp
+++ b/src/navigation_item.hpp
@@ -1,0 +1,27 @@
+#ifndef NAVIGATION_ITEM_HPP_
+#define NAVIGATION_ITEM_HPP_
+
+#include <wx/wxprec.h>
+#ifndef WX_PRECOMP
+    #include <wx/wx.h>
+#endif
+
+#include "data_manager.hpp"
+
+class NavigationItem : public wxButton {
+ public:
+  NavigationItem(wxWindow *parent,
+                 wxWindowID id,
+                 const wxString &label = wxEmptyString,
+                 const DataManager::PanelId target =
+                 DataManager::PanelId::kDefaultPanel,
+                 const wxPoint &pos = wxDefaultPosition,
+                 const wxSize &size = wxDefaultSize,
+                 int64_t style = 0);
+  DataManager::PanelId GetTarget();
+
+ private:
+  DataManager::PanelId target_;
+};
+
+#endif  // NAVIGATION_ITEM_HPP_

--- a/src/panels/details_panel.cpp
+++ b/src/panels/details_panel.cpp
@@ -13,21 +13,23 @@ DetailsPanel::DetailsPanel(wxWindow *parent,
   : DataPanel(parent, id, panel_name, panel_title, pos, size, style) {
   wxLogDebug("DetailsPanel::DetailsPanel() START");
   text_ctrl_name_ = new wxTextCtrl(this, wxID_ANY, wxEmptyString);
+  wxLogDebug("a1");
   text_ctrl_surname_ = new wxTextCtrl(this, wxID_ANY, wxEmptyString);
+  wxLogDebug("ka2");
   spin_ctrl_age_ = new wxSpinCtrl(this, wxID_ANY, wxEmptyString,
                                   wxDefaultPosition, wxDefaultSize,
                                   wxSP_VERTICAL | wxSP_ARROW_KEYS,
                                   0, 100, 18);
-
-  // TODO(egeldenhuys):
-  // - Handle Invalid date exception when text is deleted
-  // - Use dd/mm/yyyy date format
+  wxLogDebug("ka3");
   datepicker_ctrl_ = new wxDatePickerCtrl(this, wxID_ANY, wxDefaultDateTime,
                                           wxDefaultPosition, wxDefaultSize,
                                           wxDP_DEFAULT | wxDP_SHOWCENTURY);
+  wxLogDebug("ka4");
   button_next_ = new wxButton(this, wxID_ANY, _("Next"));
+  wxLogDebug("ka5");
   button_next_->Bind(wxEVT_BUTTON, &DetailsPanel::OnButtonNextClick, this,
                     wxID_ANY);
+  wxLogDebug("6");
   SetProperties();
   DoLayout();
   wxLogDebug("DetailsPanel::DetailsPanel() END");

--- a/src/questions_panel.cpp
+++ b/src/questions_panel.cpp
@@ -20,8 +20,6 @@ QuestionsPanel::~QuestionsPanel() {
 }
 
 wxPanel *QuestionsPanel::CreateInternalPanel(std::string question) {
-  wxLogDebug(_("Creating question panel: ") + _(question));
-
   wxPanel *panel = new wxPanel(this, wxID_ANY);
   // panel->Hide();
   wxFlexGridSizer *sizer = new wxFlexGridSizer(2, 3, 10, 0);
@@ -60,8 +58,6 @@ bool QuestionsPanel::SetGuiState(std::shared_ptr<cpptoml::table> state) {
     state->get_table(this->GetPanelName());
 
   if (panel_table) {
-    std::cout << *panel_table << std::endl;
-
     // We can get the array named questions since we already
     // extracted the panel table.
     // ie the '[[panel_name.questions]]' becomes '[[questions]]'


### PR DESCRIPTION
### Added
- Add a static navigation panel (closes #63)

### Removed
- Extra debug logging

### Notes
The wxWidgets components for list and tree view did not provide the required flexibility. So I used buttons instead. A flat style would be more appealing and menu-like, this can probably be done by creating a custom component or bitmap buttons.

### TODO
- [ ] Highlight active button
- [ ] Collapse groups (Details, Assessment, Theme Analysis, Mission)

![navbar](https://user-images.githubusercontent.com/5778739/34406678-0e8f4f7a-ebc3-11e7-92da-7f9945683ca5.png)
