### PR TITLE
Automate Building of wxWidgets and Prothesis-2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+dist: trusty
+sudo: required
+cache:
+  directories:
+  - "$HOME/wxWidgets"
+language: cpp
+env:
+  - WX_INSTALL_PATH_LINUX=$HOME/wxWidgets/gtk2u
+install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y gtk2.0
+  - ./build-wxwidgets-init.sh
+  - make get-deps
+script:
+  - ./build-prothesis-2-init.sh

--- a/README.md
+++ b/README.md
@@ -1,36 +1,21 @@
 # Prothesis v2
 
+Prothesis software for Target Life
+
 ## Building
 ### Linux
-```
-make linux -j4
-
-./build/prothesis-2
-```
-
-### Windows
-- **NOTE:* A Windows build using 4 cores may use up to 2 GB of RAM
+#### wxWidgets
+View the `build-wxwidgets.sh` for more information
 
 ```
-# Set config used in makefile
-echo "path/to/static/msw-wxwidgets" > .win_wx_static_config
-
-make windows -j4
-
-./build/prothesis-2.exe
+./build-wxwidgets.sh <root_dir> linux
 ```
+- wxWidgets will be installed at <root_dir>/wxWidgets/gtk2u
+- wxWidgets source will be at <root_dir>/wxWidgets-3.0.3-linux
+- wxWidgets source archive will be downloaded to <root_dir>/wxWidgets-3.0.3.tar.bz2
 
-## Linter
-The source is automatically linted when using the makefile.
-It will stop compiling if there is a linting error.
-
-```
-./get-cpplint.sh
-./lint.sh
-```
-
-## Development
-### Dependencies
+#### Prothesis-2
+##### Dependencies
 - [wxWidgets 3.0.3](https://github.com/prothesis-software/prothesis-2/wiki/Compiling-wxWidgets)
   - `gtk2`
   - `make`
@@ -41,11 +26,39 @@ It will stop compiling if there is a linting error.
   - Static msw build of wxWidgets for Windows cross compilation
 - `python2` (for linting)
 - `wget` (downloading dependencies)
-- `cpplint.py` (run `get-cpplint.sh`)
-- `cpptoml.h` (run `get-cpptoml.sh`)
+- `cpplint.py` (run `make get-deps`)
+- `cpptoml.h` (run `make get-deps`)
+
+```
+export WX_INTALL_PATH_LINUX=<root_dir>/wxWidgets/gtku2/
+make linux -j $(nproc)
+```
+
+### Windows
+#### wxWidgets
+- Install MSYS2 (see wiki)
+
+```
+# Install dependencies
+pacman -S git mingw-w64-i686-gcc python2 p7zip make patch
+
+# Build wxWidgets
+./build-wxdigets <root_dir> windows
+```
+
+#### Prothesis-2
+##### Dependencies
+```
+pacman -S mingw-w64-i686-g++
+```
+
+##### Building
+```
+export WX_INSTALL_PATH_WINDOWS=<root_dir>/wxWidgets/mswu-static
+make windows -j ($nproc)
+```
 
 ## Deploying
-
 ### Linux
 #### Dependencies
 - `gtk2`

--- a/build-prothesis-2-init.sh
+++ b/build-prothesis-2-init.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Script to build prothesis-2 based on the set environment variables
+# Used for Travis CI
+
+# Variables to watch for:
+# - WX_INSTALL_PATH_LINUX
+# - WX_INSTALL_PATH_WINDOWS
+# - WX_INSTALL_PATH_WINDOWS_CROSS
+
+echo "Starting build-prothesis-2-init.sh ..."
+
+if ! [ -z ${WX_INSTALL_PATH_LINUX+x} ]; then
+    echo "WX_INSTALL_PATH_LINUX has been set, building prothesis-2 for Linux"
+    make linux -j $(nproc)
+fi
+
+if ! [ -z ${WX_INSTALL_PATH_WINDOWS_CROSS+x} ]; then
+    echo "WX_INSTALL_PATH_WINDOWS_CROSS has been set, building prothesis-2 for windows-cross"
+    make windows CXX=i686-w64-mingw32-g++ WINDRES=i686-w64-mingw32-windres -j $(nproc)
+fi
+
+if ! [ -z ${WX_INSTALL_PATH_WINDOWS+x} ]; then
+    echo "WX_INSTALL_PATH_WINDOWS has been set, building prothesis-2 for Windows"
+    make windows -j $(nproc)
+fi

--- a/build-wxwidgets-init.sh
+++ b/build-wxwidgets-init.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Script to build wxWidgets based on the set environment variables
+# Used for Travis CI
+
+# Variables to watch for:
+# - WX_INSTALL_PATH_LINUX
+# - WX_INSTALL_PATH_WINDOWS
+# - WX_INSTALL_PATH_WINDOWS_CROSS
+
+echo "Starting build-wxwidgets-init.sh ..."
+
+if ! [ -z ${WX_INSTALL_PATH_LINUX+x} ]; then
+    echo "WX_INSTALL_PATH_LINUX has been set, building wxWidgets for Linux"
+    ./build-wxwidgets.sh $HOME linux
+fi
+
+if ! [ -z ${WX_INSTALL_PATH_WINDOWS_CROSS+x} ]; then
+    echo "WX_INSTALL_PATH_WINDOWS_CROSS has been set, building wxWidgets for windows-cross"
+    ./build-wxwidgets.sh $HOME windows-cross
+fi
+
+if ! [ -z ${WX_INSTALL_PATH_WINDOWS+x} ]; then
+    echo "WX_INSTALL_PATH_WINDOWS has been set, building wxWidgets for Windows"
+    ./build-wxwidgets.sh $HOME windows
+fi

--- a/build-wxwidgets.sh
+++ b/build-wxwidgets.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+
+# DESCRIPTION:
+# Downloads and builds wxWidgets-3.0.3 for Linux and Windows (MSYS2)
+
+# USAGE:
+# ./build-wxwidgets.sh <root_dir> <windows|windows-cross|linux>
+#
+# Example:
+# ./build-wxwidgets.sh $HOME linux
+
+# OUTPUTS in $ROOT_DIR:
+# - wxWidgets-3.0.3-source-<linux|windows>
+# - wxWidgets/<gtk2u|mswu-static|mswu-static-cross>
+# - wxWidgets-3.0.3.<tar.bz2|7z>
+
+# DEPENDENCIES:
+# ## Common:
+# - wget
+# - patch
+# - autotools
+# - make
+#
+# ## linux:
+# - tar
+# - gcc
+#
+# ## windows:
+# - p7zip
+# - mingw-w64-x86_x64-gcc
+# - mingw-w64-i686-gcc
+#
+# ## windows-cross:
+# - mingw-w64-gcc
+
+# POSITIONAL ARGS
+ROOT_DIR=$1
+TARGET=$2
+
+# DEFAULTS
+if [ -z ${TRAVIS_BUILD_DIR+x} ]; then
+    TRAVIS_BUILD_DIR=$PWD
+fi
+
+if [ -z ${CROSS_BUILD+x} ]; then
+    CROSS_BUILD=x86_64-unknown-linux-gnu
+fi
+
+if [ -z ${CROSS_HOST+x} ]; then
+    CROSS_HOST=i686-w64-mingw32
+fi
+
+# '-linux' or '-windows' is later appended depending on target
+SOURCE_DIR=$ROOT_DIR/wxWidgets-3.0.3-source
+LINUX_INSTALL_DIR=$ROOT_DIR/wxWidgets/gtk2u
+WINDOWS_INSTALL_DIR=$ROOT_DIR/wxWidgets/mswu-static
+WINDOWS_CROSS_INSTALL_DIR=$ROOT_DIR/wxWidgets/mswu-static-cross
+
+cd $ROOT_DIR
+
+if [ "$TARGET" == "linux" ]; then
+    # Check if cache exists
+    if ! [ -d $LINUX_INSTALL_DIR ]; then
+        SOURCE_DIR=$SOURCE_DIR-linux
+        BUILD_DIR=build-gtk2u
+
+        # Download and extract source
+        wget -nc https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.3/wxWidgets-3.0.3.tar.bz2
+        echo "Extracting wxWidgets-3.0.3.tar.bz2"
+        mkdir -p $SOURCE_DIR
+        tar -xf wxWidgets-3.0.3.tar.bz2 --strip 1 -C $SOURCE_DIR
+
+        # Patch extra ;
+        patch --forward --force $SOURCE_DIR/include/wx/filefn.h $TRAVIS_BUILD_DIR/wxwidgets.patch
+
+        cd $SOURCE_DIR
+
+        # Build and Install
+        mkdir -p $BUILD_DIR
+        cd $BUILD_DIR
+        ../configure --prefix=$LINUX_INSTALL_DIR \
+                     --enable-unicode \
+                     --with-gtk=2
+        make -j $(nproc)
+        make install
+    else
+        echo "wxWidgets has already been build for Windows"
+    fi
+elif [ "$TARGET" == "windows" ]; then
+    # Check if cache exists
+    if ! [ -d $WINDOWS_INSTALL_DIR ]; then
+        SOURCE_DIR=$SOURCE_DIR-windows
+        BUILD_DIR=build-mswu-static
+
+        # Download and extract source
+        wget -nc https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.3/wxWidgets-3.0.3.7z
+        # p7zip deletes original file, so preserve it
+        cp wxWidgets-3.0.3.7z wxWidgets-3.0.3-tmp.7z
+        mkdir -p $SOURCE_DIR
+        cd $SOURCE_DIR
+        echo "Extracting wxWidgets-3.0.3-tmp.7z ..."
+        # Overwrite existing files
+        echo "A" | p7zip -d ../wxWidgets-3.0.3-tmp.7z &> /dev/null
+        cd ../
+
+        # Patch extra ;
+        patch --forward --force $SOURCE_DIR/include/wx/filefn.h $TRAVIS_BUILD_DIR/wxwidgets.patch
+
+        cd $SOURCE_DIR
+
+        # Build and Install
+        mkdir -p $BUILD_DIR
+        cd $BUILD_DIR
+        ../configure --prefix=$WINDOWS_INSTALL_DIR \
+                     --enable-unicode \
+                     --disable-shared \
+                     --with-msw
+        make -j $(nproc)
+        make install
+    else
+        echo "wxWidgets has already been build for Windows"
+    fi
+elif [ "$TARGET" == "windows-cross" ]; then
+    # Check if cache exists
+    if ! [ -d $WINDOWS_CROSS_INSTALL_DIR ]; then
+        SOURCE_DIR=$SOURCE_DIR-linux
+        BUILD_DIR=build-mswu-static-cross
+
+        # Download and extract source
+        wget -nc https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.3/wxWidgets-3.0.3.tar.bz2
+        echo "Extracting wxWidgets-3.0.3.tar.bz2"
+        mkdir -p $SOURCE_DIR
+        tar -xf wxWidgets-3.0.3.tar.bz2 --strip 1 -C $SOURCE_DIR
+
+        # Patch extra ;
+        patch --forward --force $SOURCE_DIR/include/wx/filefn.h $TRAVIS_BUILD_DIR/wxwidgets.patch
+
+        cd $SOURCE_DIR
+
+        # Build and Install
+        mkdir -p $BUILD_DIR
+        cd $BUILD_DIR
+        ../configure --prefix=$WINDOWS_CROSS_INSTALL_DIR \
+                     --build=$CROSS_BUILD \
+                     --host=$CROSS_HOST \
+                     --enable-unicode \
+                     --disable-shared \
+                     --with-msw \
+                     CFLAGS=-I/usr/$CROSS_HOST/include
+        make -j $(nproc)
+        make install
+    else
+        echo "wxWidgets has already been build for windows-cross"
+    fi
+else
+    echo "ERROR: Unknown target!"
+fi

--- a/wxwidgets.patch
+++ b/wxwidgets.patch
@@ -1,0 +1,4 @@
+220c220
+<         wxDECL_FOR_STRICT_MINGW32(int, fseeko64, (FILE*, long long, int));
+---
+>         wxDECL_FOR_STRICT_MINGW32(int, fseeko64, (FILE*, long long, int))


### PR DESCRIPTION
### Added
- Script to build wxWidgets on Linux, Windows and cross compile for Windows (closes #91)
- Init scripts as shortcuts for building when the env vars have been set
- Travis CI support
  - wxWidgets will be compiled and cached on Travis CI
  - Cross compilation does not work on Travis CI. AppVeyor is required for Windows builds

### Changed
- README now contains latest information on building
#### Makefile
- The makefile now uses the following env vars instead of `.wx_win_static_config` for finding `wx-config`
  - `WX_INSTALL_PATH_LINUX` 
  - `WX_INSTALL_PATH_WINDOWS`
  - `WX_INSTALL_PATH_WINDOWS_CROSS`
- For linux it should still work without setting the env var if wxWidgets has been installed
- `get-deps` Target to download `cpplint.py` and `cpptoml.h`

#### Building
- Unicode is now used for building wxWidgets and Prothesis-2. See [wxWidgets: Unicode Support](http://docs.wxwidgets.org/3.1/overview_unicode.html)
- 32 bit binaries are generated when cross compiling.