### PR TITLE
Wrap question label

### DIFF
--- a/src/questions_panel.cpp
+++ b/src/questions_panel.cpp
@@ -30,7 +30,9 @@ wxPanel *QuestionsPanel::CreateInternalPanel(std::string question) {
                                                 wxDefaultSize,
                                                 wxTE_MULTILINE);
   // WARN:STATIC
-  text_ctrl_answer->SetMinSize(wxSize(400, 100));
+  text_ctrl_answer->SetMinSize(wxSize(ANSWER_WIDTH, ANSWER_HEIGHT));
+  question_text->Wrap(QUESTION_WRAP_WIDTH);
+
   sizer->Add(0, 0, 0, 0);
   sizer->Add(question_text, 0, wxALL | wxALIGN_CENTER, 5);
   sizer->Add(0, 0, 0, 0);

--- a/src/questions_panel.hpp
+++ b/src/questions_panel.hpp
@@ -12,6 +12,10 @@
 
 #include "paged_panel.hpp"
 
+#define QUESTION_WRAP_WIDTH 600
+#define ANSWER_WIDTH 400
+#define ANSWER_HEIGHT 100
+
 class QuestionsPanel : public PagedPanel {
  public:
   QuestionsPanel(wxWindow* parent,


### PR DESCRIPTION
### Added
- Question label is now wrapped at 600px (closes #100)

### Screenshots
![wrap1](https://user-images.githubusercontent.com/5778739/34522652-57371a54-f09c-11e7-9993-1acc24b7b980.png)

![wrap2](https://user-images.githubusercontent.com/5778739/34522653-5779dfba-f09c-11e7-92f4-35c4be18dea1.png)

  