### PR TITLE
Handle TOML Parse errors

### DIFF
--- a/gui.toml
+++ b/gui.toml
@@ -21,7 +21,7 @@
     [[passion.question]]
         question = "If you were to wake up tomorrow feeling truly free and happily excited about your day ahead, what  would you be off to do?"
     [[passion.question]]
-        question = "You are totally ‘in your element’ and time seems to have disappeared. What are you doing?"
+        question = "You are totally 'in your element' and time seems to have disappeared. What are you doing?"
     [[passion.question]]
         question = "It is your birthday and somebody buys you an annual magazine subscription. Which type would you love it to be?"
     [[passion.question]]
@@ -91,7 +91,7 @@
     [[dreams.question]]
         question = "Are there any people in your life preventing you from pursuing your passion? Who are they and how are they holding you back?"
     [[dreams.question]]
-        question = "What is something (or several things) you’d really like to achieve before you die?"
+        question = "What is something (or several things) you'd really like to achieve before you die?"
 
 #########################################
 # VALUES

--- a/src/checkbox_panel.cpp
+++ b/src/checkbox_panel.cpp
@@ -12,7 +12,8 @@ CheckBoxPanel::CheckBoxPanel(wxWindow *parent, wxWindowID id,
 }
 
 CheckBoxPanel::~CheckBoxPanel() {
-  // void
+  wxLogDebug(_("CheckBoxPanel::~CheckBoxPanel(): ") +
+             _(this->GetPanelName()));
 }
 
 bool CheckBoxPanel::SetGuiState(std::shared_ptr<cpptoml::table> state) {

--- a/src/data_manager.hpp
+++ b/src/data_manager.hpp
@@ -21,6 +21,7 @@
 #include "panels/external_panel.hpp"
 #include "panels/work_environment_panel.hpp"
 #include "panels/details_panel.hpp"
+#include "panels/priorities_panel.hpp"
 
 /**
  * The Data Manager class is responsible for storing reference
@@ -50,7 +51,7 @@ class DataManager {
     kValuesPanel = 4,
     kSpokenWordsPanel = 5,
     kSkillsPanel = 6,
-    kExternalPanel = 7, 
+    kExternalPanel = 7,
     kWorkEnvironmentPanel = 8,
     kPrioritiesPanel = 9,
     kPanelCount = 10

--- a/src/data_manager.hpp
+++ b/src/data_manager.hpp
@@ -6,6 +6,8 @@
     #include <wx/wx.h>
 #endif
 
+#include <wx/dialog.h>
+
 #include <wx/log.h>
 #include <vector>
 #include <string>
@@ -84,7 +86,7 @@ class DataManager {
    * Reads the user and gui config and initializes each panel
    * with the config data
    */
-  void Load();
+  bool Load();
 
   /**
    * All panels are declared in this function

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -52,13 +52,16 @@ void MainFrame::OnClose(wxCloseEvent &e) {
 }
 
 void MainFrame::OnNotebookSelectionChange(wxBookCtrlEvent& event) {
-  int index = notebook_->GetSelection();
-  DataManager::PanelId id = data_manager_->GetIdFromIndex(index);
+  // Only do stuff if there are still objects to work with
+  if (!exit_requested_) {
+    int index = notebook_->GetSelection();
+    DataManager::PanelId id = data_manager_->GetIdFromIndex(index);
 
-  DataPanel *panel = data_manager_->GetPanelById(id);
-  active_panel_ = panel;
-  active_panel_id_ = id;
-  SetHeaderTitle(active_panel_->GetPanelTitle());
+    DataPanel *panel = data_manager_->GetPanelById(id);
+    active_panel_ = panel;
+    active_panel_id_ = id;
+    SetHeaderTitle(active_panel_->GetPanelTitle());
+  }
 }
 
 void MainFrame::DisplayPanelById(DataManager::PanelId id) {
@@ -203,7 +206,9 @@ void MainFrame::DoLayout() {
 
 MainFrame::~MainFrame() {
   wxLogDebug("MainFrame::~MainFrame() START");
+  exit_requested_ = true;
   data_manager_->SaveUserConfig();
   delete data_manager_;
+  delete notebook_;
   wxLogDebug("MainFrame::~MainFrame() END");
 }

--- a/src/main_frame.hpp
+++ b/src/main_frame.hpp
@@ -56,6 +56,7 @@ class MainFrame: public wxFrame {
   wxFlexGridSizer *sizer_content_ = NULL;
   wxStaticText *label_title_ = NULL;
   wxPanel *panel_main_ = NULL;
+  bool exit_requested_ = false;
 
   /**
    * Display the given panel and adds it to the sizer

--- a/src/panels/details_panel.cpp
+++ b/src/panels/details_panel.cpp
@@ -134,5 +134,5 @@ bool DetailsPanel::SetUserState(std::shared_ptr<cpptoml::table> state) {
 }
 
 DetailsPanel::~DetailsPanel() {
-  // wxLogDebug("DetailsPanel::~DetailsPanel()");
+  wxLogDebug("DetailsPanel::~DetailsPanel()");
 }

--- a/src/panels/external_panel.cpp
+++ b/src/panels/external_panel.cpp
@@ -22,7 +22,7 @@ ExternalPanel::ExternalPanel(wxWindow *parent,
 }
 
 ExternalPanel::~ExternalPanel() {
-  // void
+  wxLogDebug("ExternalPanel::~ExternalPanel()");
 }
 
 

--- a/src/panels/priorities_panel.cpp
+++ b/src/panels/priorities_panel.cpp
@@ -33,7 +33,7 @@ PrioritiesPanel::PrioritiesPanel(wxWindow *parent,
 }
 
 PrioritiesPanel::~PrioritiesPanel() {
-  // void
+  wxLogDebug("PrioritiesPanel::~PrioritiesPanel()");
 }
 
 void PrioritiesPanel::GetItemHeight(wxListBox *list) {

--- a/src/panels/work_environment_panel.cpp
+++ b/src/panels/work_environment_panel.cpp
@@ -26,7 +26,7 @@ WorkEnvironmentPanel::WorkEnvironmentPanel(wxWindow *parent,
 }
 
 WorkEnvironmentPanel::~WorkEnvironmentPanel() {
-  // void
+  wxLogDebug("WorkEnvironmentPanel::~WorkEnvironmentPanel()");
 }
 
 bool WorkEnvironmentPanel::SetGuiState(std::shared_ptr<cpptoml::table> state) {

--- a/src/questions_panel.cpp
+++ b/src/questions_panel.cpp
@@ -16,7 +16,8 @@ QuestionsPanel::QuestionsPanel(wxWindow *parent,
 }
 
 QuestionsPanel::~QuestionsPanel() {
-  // wxLogDebug("QuestionsPanel::~QuestionsPanel()");
+  wxLogDebug(_("QuestionsPanel::~QuestionsPanel(): ") +
+             _(this->GetPanelName()));
 }
 
 wxPanel *QuestionsPanel::CreateInternalPanel(std::string question) {
@@ -73,7 +74,6 @@ bool QuestionsPanel::SetGuiState(std::shared_ptr<cpptoml::table> state) {
         // Get the question text from the table we extracted
         cpptoml::option<std::string> question_text =
           table->get_as<std::string>("question");
-
         if (question_text) {
           wxPanel* internal_panel = CreateInternalPanel(*question_text);
           AddPage(internal_panel);


### PR DESCRIPTION
### Added
- Handle TOML parse errors

### Changed
- Replaced foreign characters in gui.toml that produces empty appearing strings. (closes #101)

### Fixed
- Errors caused by merge conflicts
  
### Screenshots
![t1](https://user-images.githubusercontent.com/5778739/34553677-8979366a-f131-11e7-9622-4c05b7e48480.png)
![t2](https://user-images.githubusercontent.com/5778739/34553678-8acf39d8-f131-11e7-9ea7-6b2a449a30f4.png)
