### PR TITLE
Two Notebooks for cleaner interface

### DIFF
--- a/src/data_manager.cpp
+++ b/src/data_manager.cpp
@@ -5,8 +5,9 @@
 #include <fstream>
 #include <vector>
 
-DataManager::DataManager(wxWindow *main_frame) {
+DataManager::DataManager(wxWindow *main_frame, wxWindow *assessments_window) {
   main_frame_ = main_frame;
+  assessments_window_ = assessments_window;
 
   std::string base_path = GetBasePath();
   wxLogDebug(_(std::string("base_path = ") + base_path));
@@ -41,47 +42,47 @@ void DataManager::DeclarePanels() {
                             std::string("Details")),
            PanelId::kDetailsPanel);
   // PASSIONS
-  AddPanel(new QuestionsPanel(main_frame_, wxID_ANY,
+  AddPanel(new QuestionsPanel(assessments_window_, wxID_ANY,
                               std::string("passion"),
                               std::string("Passion")),
            PanelId::kPassionPanel);
   // PEOPLE ID
-  AddPanel(new QuestionsPanel(main_frame_, wxID_ANY,
+  AddPanel(new QuestionsPanel(assessments_window_, wxID_ANY,
                               std::string("people_id"),
                               std::string("People ID")),
            PanelId::kPeopleIdPanel);
   // DREAMS
-  AddPanel(new QuestionsPanel(main_frame_, wxID_ANY,
+  AddPanel(new QuestionsPanel(assessments_window_, wxID_ANY,
                               std::string("dreams"),
                               std::string("Dreams")),
            PanelId::kDreamsPanel);
   // VALUES
-  AddPanel(new QuestionsPanel(main_frame_, wxID_ANY,
+  AddPanel(new QuestionsPanel(assessments_window_, wxID_ANY,
                               std::string("values"),
                               std::string("Values")),
            PanelId::kValuesPanel);
   // SPOKEN WORDS
-  AddPanel(new QuestionsPanel(main_frame_, wxID_ANY,
+  AddPanel(new QuestionsPanel(assessments_window_, wxID_ANY,
                               std::string("spoken_words"),
                               std::string("Spoken Words")),
            PanelId::kSpokenWordsPanel);
   // SKILLS
-  AddPanel(new CheckBoxPanel(main_frame_, wxID_ANY,
+  AddPanel(new CheckBoxPanel(assessments_window_, wxID_ANY,
                               std::string("skills"),
                               std::string("Skills")),
            PanelId::kSkillsPanel);
     // PRIORITIES
-  AddPanel(new PrioritiesPanel(main_frame_, wxID_ANY,
+  AddPanel(new PrioritiesPanel(assessments_window_, wxID_ANY,
                               std::string("priorities"),
                               std::string("Priorities")),
            PanelId::kPrioritiesPanel);
   // EXTERNAL
-  AddPanel(new ExternalPanel(main_frame_, wxID_ANY,
+  AddPanel(new ExternalPanel(assessments_window_, wxID_ANY,
                               std::string("external"),
                               std::string("External")),
            PanelId::kExternalPanel);
   // WORK ENVIRONMENT
-  AddPanel(new WorkEnvironmentPanel(main_frame_, wxID_ANY,
+  AddPanel(new WorkEnvironmentPanel(assessments_window_, wxID_ANY,
                              std::string("work_environment"),
                              std::string("Work Environment")),
            PanelId::kWorkEnvironmentPanel);
@@ -141,6 +142,19 @@ bool DataManager::Load() {
   }
 
   return true;
+}
+
+DataManager::PanelId DataManager::GetIdFromName(std::string name) {
+  for (size_t i = 0; i < DataManager::PanelId::kPanelCount; i++) {
+    if (panels_[i]->GetPanelName().compare(name) == 0) {
+      return GetIdFromIndex(i);
+    }
+  }
+
+  wxLogWarning(_("Could not find panel with the name '") +
+               _(name));
+
+  return PanelId::kDefaultPanel;
 }
 
 DataManager::PanelId DataManager::GetIdFromIndex(size_t index) {

--- a/src/data_manager.hpp
+++ b/src/data_manager.hpp
@@ -36,7 +36,7 @@ class DataManager {
    * Initializes all panels from the GUI config and the User config and adds
    * them as children to the MainFrame
    */
-  explicit DataManager(wxWindow *main_frame);
+  explicit DataManager(wxWindow *main_frame, wxWindow *assessments_window);
 
   ~DataManager();
 
@@ -81,6 +81,8 @@ class DataManager {
 
   PanelId GetIdFromIndex(size_t index);
 
+  DataManager::PanelId GetIdFromName(std::string name);
+
  private:
   /**
    * Reads the user and gui config and initializes each panel
@@ -103,6 +105,7 @@ class DataManager {
   DataManager::PanelId ids_[PanelId::kPanelCount];
 
   wxWindow *main_frame_ = NULL;
+  wxWindow *assessments_window_ = NULL;
 
   // Paths are relative to the base directory of the binary
   std::string gui_config_path_ = "gui.toml";

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -75,7 +75,7 @@ void MainFrame::DisplayPanelById(DataManager::PanelId id) {
     Refresh();
   }
 
-  if (id == DataManager::PanelId::kExternalPanel) {
+  if (id == DataManager::PanelId::kWorkEnvironmentPanel) {
     active_panel_->GetUserState();
   }
 }

--- a/src/main_frame.hpp
+++ b/src/main_frame.hpp
@@ -10,6 +10,7 @@
 #include <wx/notebook.h>
 
 #include <string>
+#include <vector>
 
 #include "data_panel.hpp"
 #include "data_manager.hpp"
@@ -23,20 +24,11 @@ class MainFrame: public wxFrame {
             const wxSize &size = wxDefaultSize,
             int64_t style = wxDEFAULT_FRAME_STYLE,
             const wxString name = wxFrameNameStr);
-  /**
-   * Display the panel with the given ID
-   */
-  void DisplayPanelById(DataManager::PanelId id);
+  ~MainFrame();
 
   bool DisplayNextPanel();
-
-  /**
-   * Set the title displayed in the header
-   */
-  void SetHeaderTitle(std::string title);
   static void OnKill(int sig);
   DataManager *data_manager_;
-  ~MainFrame();
 
   /**
    * Returns the minimun size that will fit every page
@@ -45,23 +37,15 @@ class MainFrame: public wxFrame {
 
  private:
   void DoLayout();
-  void SetProperties();
   void OnClose(wxCloseEvent &e); // NOLINT
-  void OnButtonNextClick(wxCommandEvent &event);  // NOLINT
   void OnNotebookSelectionChange(wxBookCtrlEvent& event);  // NOLINT
   wxNotebook *notebook_ = NULL;
-  DataManager::PanelId active_panel_id_;
-  DataPanel *active_panel_ = NULL;
+  wxNotebook *notebook_assessments_ = NULL;
   wxFlexGridSizer *sizer_main_frame_ = NULL;
   wxFlexGridSizer *sizer_content_ = NULL;
-  wxStaticText *label_title_ = NULL;
   wxPanel *panel_main_ = NULL;
   bool exit_requested_ = false;
-
-  /**
-   * Display the given panel and adds it to the sizer
-   */
-  void DisplayPanel_deprecated(DataPanel *panel);
+  std::vector<std::vector<DataPanel*>> index_layout_;
 };
 
 #endif  // MAIN_FRAME_HPP_

--- a/src/navigation_drawer.cpp
+++ b/src/navigation_drawer.cpp
@@ -19,7 +19,7 @@ void NavigationDrawer::SetProperties() {
 
 void NavigationDrawer::OnItemClick(wxCommandEvent &event) {
   NavigationItem *item = static_cast<NavigationItem*>(event.GetEventObject());
-  MainFrame *main_frame = static_cast<MainFrame*>(wxTheApp->GetTopWindow());
+  // MainFrame *main_frame = static_cast<MainFrame*>(wxTheApp->GetTopWindow());
 
   // \note triggers for clicking on nav buttons
   if (item->GetTarget() == DataManager::kWorkEnvironmentPanel) {
@@ -31,7 +31,7 @@ void NavigationDrawer::OnItemClick(wxCommandEvent &event) {
     }
   }
 
-  main_frame->DisplayPanelById(item->GetTarget());
+  // main_frame->DisplayPanelById(item->GetTarget());
 }
 
 void NavigationDrawer::AddItem(std::string label, DataManager::PanelId target,

--- a/src/panels/work_environment_panel.cpp
+++ b/src/panels/work_environment_panel.cpp
@@ -68,7 +68,7 @@ void WorkEnvironmentPanel::FitText() {
 
   wxLogDebug(_(std::to_string(width)));
   text_description_->SetMinSize(wxSize(width, -1));
-  text_description_->SetMaxSize(wxSize(width, -1));
+  // text_description_->SetMaxSize(wxSize(width, -1));
   Layout();
 }
 
@@ -152,4 +152,5 @@ void WorkEnvironmentPanel::DoLayout() {
   sizer->Add(label_mbti_, 0, wxEXPAND | wxALIGN_CENTER, 0);
   sizer->Add(text_description_, 1, wxEXPAND | wxALIGN_CENTER, 0);
   this->SetSizer(sizer);
+  sizer->Fit(this);
 }


### PR DESCRIPTION
### Added
- Moved Assessments to its own Notebook

### Removed
- Title and Next button in MainFrame

### Changed
- Work Environment text box is now fit to the parent panel

Closes #116 

### Screenshots
![moar1](https://user-images.githubusercontent.com/5778739/34610245-ee25f5ba-f228-11e7-8b7f-41f448f86504.png)
![moar2](https://user-images.githubusercontent.com/5778739/34610246-ee66f79a-f228-11e7-8822-cb54fa0eff1b.png)
![moar3](https://user-images.githubusercontent.com/5778739/34610247-eea8c7c4-f228-11e7-8837-6c7d802922dc.png)
![moar4](https://user-images.githubusercontent.com/5778739/34610248-eee8331e-f228-11e7-9c73-7b95fa68f643.png)

