### PR TITLE
Add career test results to External panel

### DIFF
--- a/src/career_test_panel.cpp
+++ b/src/career_test_panel.cpp
@@ -1,0 +1,91 @@
+#include "career_test_panel.hpp"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+CareerTestPanel::CareerTestPanel(wxWindow* parent, wxWindowID id,
+                                 std::string panel_name,
+                                 std::string panel_title, const wxPoint& pos,
+                                 const wxSize& size, int64_t style)
+    : DataPanel(parent, id, panel_name, panel_title, pos, size, style) {
+  DoLayout();
+}
+
+CareerTestPanel::~CareerTestPanel() {
+  // void
+}
+
+bool CareerTestPanel::SetGuiState(std::shared_ptr<cpptoml::table> state) {
+  return false;
+}
+
+bool CareerTestPanel::SetUserState(std::shared_ptr<cpptoml::table> state) {
+  auto panel_table = state->get_table(this->GetPanelName());
+
+  if (panel_table) {
+    for (size_t i = 0; i < 4; i++) {
+      auto str =
+          panel_table->get_as<std::string>("interest_" + std::to_string(i + 1));
+      auto perc = panel_table->get_as<int>("interest_" + std::to_string(i + 1) +
+                                           "_percentage");
+
+      if (str) {
+        text_interests_.at(i)->SetValue(*str);
+      }
+      if (perc) {
+        spin_ctrl_percentages_.at(i)->SetValue(*perc);
+      }
+    }
+  } else {
+    return false;
+  }
+
+  return true;
+}
+
+std::shared_ptr<cpptoml::table> CareerTestPanel::GetUserState() {
+  auto panel_table = cpptoml::make_table();
+
+  for (size_t i = 0; i < 4; i++) {
+    panel_table->insert("interest_" + std::to_string(i + 1),
+                        text_interests_.at(i)->GetValue().ToStdString());
+
+    panel_table->insert("interest_" + std::to_string(i + 1) + "_percentage",
+                        spin_ctrl_percentages_.at(i)->GetValue());
+  }
+
+  return panel_table;
+}
+
+void CareerTestPanel::DoLayout() {
+  wxStaticBoxSizer* sizer =
+      new wxStaticBoxSizer(wxVERTICAL, this, this->GetPanelTitle());
+  wxFlexGridSizer* sizer_content = new wxFlexGridSizer(5, 2, 0, 0);
+
+  wxStaticText* label_interest =
+      new wxStaticText(sizer->GetStaticBox(), wxID_ANY, "Interest");
+  wxStaticText* label_perc =
+      new wxStaticText(sizer->GetStaticBox(), wxID_ANY, "%");
+
+  sizer_content->Add(label_interest, 0, wxALIGN_CENTER, 0);
+  sizer_content->Add(label_perc, 0, wxALIGN_CENTER, 0);
+
+  for (size_t i = 0; i < 4; i++) {
+    wxTextCtrl* text_interest = new wxTextCtrl(sizer->GetStaticBox(), wxID_ANY);
+    wxSpinCtrl* spin_ctrl = new wxSpinCtrl(sizer->GetStaticBox(), wxID_ANY);
+
+    text_interest->SetMinSize(wxSize(200, -1));
+    spin_ctrl->SetMinSize(wxSize(75, -1));
+
+    sizer_content->Add(text_interest, 1, wxALL, 5);
+    sizer_content->Add(spin_ctrl, 0, wxALL, 5);
+
+    text_interests_.push_back(text_interest);
+    spin_ctrl_percentages_.push_back(spin_ctrl);
+  }
+
+  sizer->Add(sizer_content);
+  this->SetSizer(sizer);
+  Layout();
+}

--- a/src/career_test_panel.hpp
+++ b/src/career_test_panel.hpp
@@ -1,0 +1,50 @@
+#ifndef CAREER_TEST_PANEL_HPP_
+#define CAREER_TEST_PANEL_HPP_
+
+#include <wx/wxprec.h>
+#ifndef WX_PRECOMP
+#include <wx/wx.h>
+#endif
+
+#include <wx/spinctrl.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "data_panel.hpp"
+
+class CareerTestPanel : public DataPanel {
+ public:
+  CareerTestPanel(wxWindow* parent, wxWindowID id, std::string panel_name,
+                  std::string panel_title,
+                  const wxPoint& pos = wxDefaultPosition,
+                  const wxSize& size = wxDefaultSize, int64_t style = 0);
+  ~CareerTestPanel();
+
+  /**
+   * Not used.
+   */
+  bool SetGuiState(std::shared_ptr<cpptoml::table> state) override;
+
+  /**
+   * TOML Specification for Getting the User state:
+   * [panel_name]
+   *   interest_1 = "Hockey"
+   *   interest_1_percentage = 54
+   *   interest_2 = "Golf"
+   *   interest_2_percentage = 0
+   */
+  std::shared_ptr<cpptoml::table> GetUserState() override;
+
+  /**
+   * TOML Specification is the same as for GetUserState()
+   */
+  bool SetUserState(std::shared_ptr<cpptoml::table> state) override;
+
+ private:
+  void DoLayout();
+  std::vector<wxTextCtrl*> text_interests_;
+  std::vector<wxSpinCtrl*> spin_ctrl_percentages_;
+};
+#endif  // CAREER_TEST_PANEL_HPP_

--- a/src/panels/external_panel.cpp
+++ b/src/panels/external_panel.cpp
@@ -114,6 +114,10 @@ std::shared_ptr<cpptoml::table> ExternalPanel::GetUserState() {
     }
   }
 
+  // career test
+  auto career_table = panel_career_->GetUserState();
+  panel_table->insert(panel_career_->GetPanelName(), career_table);
+
   if (keys_found > 0) {
     life_keys_table->insert("type", life_keys_table_array);
     panel_table->insert("life_keys", life_keys_table);
@@ -196,6 +200,8 @@ bool ExternalPanel::SetUserState(std::shared_ptr<cpptoml::table> state) {
       wxLogDebug(_("mbti array not found for external panel"));
     }
 
+    panel_career_->SetUserState(panel_table);
+
   } else {
     wxLogDebug(_("No GUI table exists for panel ") + _(this->GetPanelName()));
     wxLogDebug(_("ExternalPanel::SetUserState() END"));
@@ -220,13 +226,13 @@ void ExternalPanel::DoLayout() {
   wxBoxSizer* sizer_mbti = new wxBoxSizer(wxVERTICAL);
   wxBoxSizer* sizer_mbti_combo_boxes = new wxBoxSizer(wxHORIZONTAL);
   wxBoxSizer* sizer_career = new wxBoxSizer(wxVERTICAL);
-  wxPanel* panel_career = new wxPanel(this, wxID_ANY);
-  panel_career->SetBackgroundColour(wxColour(255, 0, 0));
-  panel_career->SetMinSize(wxSize(200, 300));
-  sizer_career->Add(panel_career, 0, wxEXPAND, 0);
+
+  panel_career_ =
+      new CareerTestPanel(this, wxID_ANY, "career_test", "Career Test");
+  sizer_career->Add(panel_career_, 0, wxEXPAND | wxALL, 5);
 
   wxStaticText* label_mbti = new wxStaticText(this, wxID_ANY, _("MBTI"));
-  sizer_mbti->Add(label_mbti, 0, wxALIGN_BOTTOM, 0);
+  sizer_mbti->Add(label_mbti, 0, wxALIGN_BOTTOM | wxALL, 5);
 
   std::vector<wxArrayString> mbti_tuples;
   AddMbtiTuple(&mbti_tuples, "I", "E");
@@ -247,10 +253,10 @@ void ExternalPanel::DoLayout() {
   sizer_keys_->Add(label_keys, 0, wxALIGN_BOTTOM, 0);
 
   sizer_mbti_keys->Add(sizer_mbti, 0, wxBOTTOM, 20);
-  sizer_mbti_keys->Add(sizer_keys_, 0, 0, 0);
+  sizer_mbti_keys->Add(sizer_keys_, 0, wxALL, 0);
 
-  sizer->Add(sizer_mbti_keys, 0, 0, 0);
-  sizer->Add(sizer_career, 0, 0, 0);
+  sizer->Add(sizer_mbti_keys, 0, wxALL, 5);
+  sizer->Add(sizer_career, 0, wxALL, 5);
 
   Layout();
   this->SetSizer(sizer);

--- a/src/panels/external_panel.hpp
+++ b/src/panels/external_panel.hpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 
+#include "src/career_test_panel.hpp"
 #include "src/data_panel.hpp"
 
 #define CHOICE_BOX_KEYS_COUNT 3
@@ -64,5 +65,6 @@ class ExternalPanel : public DataPanel {
   wxBoxSizer* sizer_keys_ = NULL;
   wxChoice* choice_boxes_keys_[CHOICE_BOX_KEYS_COUNT];
   wxChoice* choice_boxes_mbti_[4];
+  CareerTestPanel* panel_career_ = NULL;
 };
 #endif  // PANELS_EXTERNAL_PANEL_HPP_


### PR DESCRIPTION
### Added
- Career test results are now in the External Panel (closes #123)

### Screenshots
![ext3](https://user-images.githubusercontent.com/5778739/34935286-0955e39e-f9e6-11e7-8732-e28a75e97d4e.png)
![ext4](https://user-images.githubusercontent.com/5778739/34935287-099dd7a8-f9e6-11e7-98e6-93655643b5c5.png)
