### PR TITLE
Add MBTI and Life Keys Info Panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Display life key information on External Panel (closes #137)
+- Display MBTI Info on External panel and Themes panel (closes #136)
+- Scroll bars for panels that are larger than the MainFrame
 - Career orientation panel (#76)
 - Added email address field to Details panel (#111)
 - Limit checkboxes and priorities to 7 (#120)
 - Menu bar with About dialog (#121)
+
+### Changed
+- Change "Theme Analysis" to "Analysis" #141
+- Place Roles tab before Skills tab #135
+- Float external panel
 
 ## [2.0.0-dev.2] - 2017-01-15
 ### Added

--- a/build-wxwidgets.sh
+++ b/build-wxwidgets.sh
@@ -80,7 +80,8 @@ if [ "$TARGET" == "linux" ]; then
         cd $BUILD_DIR
         ../configure --prefix=$LINUX_INSTALL_DIR \
                      --enable-unicode \
-                     --with-gtk=2
+                     --with-gtk=2 \
+                     CXXFLAGS="--std=c++11"
         make -j $(nproc)
         make install
     else

--- a/gui.toml
+++ b/gui.toml
@@ -1,195 +1,266 @@
-###################################
-# SPECIFICATION
-###############
-# - The top level key is the id string of the responsible panel
-# - https://toolkit.site/format.html
-# --------------------------------
+# Formatter:
+#   https://toolkit.site/format.html
 
 ####################################
 # PASSION
 ###########
 
 [passion]
-    [[passion.question]]
-        question = "What are your 3 favourite topics to discuss? What could you talk about for hours on end?"
-    [[passion.question]]
-        question = "What things in life really make you feel free?"
-    [[passion.question]]
-        question = "Let 5 people who love and know you best tell you that you would be amazing at doing for a living."
-    [[passion.question]]
-        question = "What naturally flows for you without you even having to try?"
-    [[passion.question]]
-        question = "If you were to wake up tomorrow feeling truly free and happily excited about your day ahead, what  would you be off to do?"
-    [[passion.question]]
-        question = "You are totally 'in your element' and time seems to have disappeared. What are you doing?"
-    [[passion.question]]
-        question = "It is your birthday and somebody buys you an annual magazine subscription. Which type would you love it to be?"
-    [[passion.question]]
-        question = "What areas of life are you naturally drawn to?"
-    [[passion.question]]
-        question = "What do people ask you for information/advice about? Which areas are you deemed to be a little fountain of knowledge?"
-    [[passion.question]]
-        question = "If you were to pioneer a cause around the world, and it was guaranteed to be a success, what would it be?"
-    [[passion.question]]
-        question = "What do you love to do when you have free time and what is it that gives you that real buzz of excitement?"
-    [[passion.question]]
-        question = "What topics interest you and what would you really love to know lots more about?"
-    [[passion.question]]
-        question = "You love helping people with these 3 different things. What are they?"
-    [[passion.question]]
-        question = "What interests or hobbies have you had in the past few years that intrigue you and might hold the potential for a life passion?"
-    [[passion.question]]
-        question = "What would be hard for you to give up?"
-    [[passion.question]]
-        question = "Now summarise the central themes from your previous answers."
+
+  [[passion.question]]
+  question = "What are your 3 favourite topics to discuss? What could you talk about for hours on end?"
+
+  [[passion.question]]
+  question = "What things in life really make you feel free?"
+
+  [[passion.question]]
+  question = "Let 5 people who love and know you best tell you that you would be amazing at doing for a living."
+
+  [[passion.question]]
+  question = "What naturally flows for you without you even having to try?"
+
+  [[passion.question]]
+  question = "If you were to wake up tomorrow feeling truly free and happily excited about your day ahead, what  would you be off to do?"
+
+  [[passion.question]]
+  question = "You are totally 'in your element' and time seems to have disappeared. What are you doing?"
+
+  [[passion.question]]
+  question = "It is your birthday and somebody buys you an annual magazine subscription. Which type would you love it to be?"
+
+  [[passion.question]]
+  question = "What areas of life are you naturally drawn to?"
+
+  [[passion.question]]
+  question = "What do people ask you for information/advice about? Which areas are you deemed to be a little fountain of knowledge?"
+
+  [[passion.question]]
+  question = "If you were to pioneer a cause around the world, and it was guaranteed to be a success, what would it be?"
+
+  [[passion.question]]
+  question = "What do you love to do when you have free time and what is it that gives you that real buzz of excitement?"
+
+  [[passion.question]]
+  question = "What topics interest you and what would you really love to know lots more about?"
+
+  [[passion.question]]
+  question = "You love helping people with these 3 different things. What are they?"
+
+  [[passion.question]]
+  question = "What interests or hobbies have you had in the past few years that intrigue you and might hold the potential for a life passion?"
+
+  [[passion.question]]
+  question = "What would be hard for you to give up?"
+
+  [[passion.question]]
+  question = "Now summarise the central themes from your previous answers."
 
 #########################################3
 # PEOPLE ID
 ################
 
 [people_id]
-    [[people_id.question]]
-        question = "5 people that inspire you most in the world stand before you. Who are they and what is it about them that sparks something within you?"
-    [[people_id.question]]
-        question = "Who is someone in your life or in history whose life and work inspires and excites you? Why?"
-    [[people_id.question]]
-        question = "Who influenced your life most and why?"
-    [[people_id.question]]
-        question = "With which character in a book or movie did you relate well and why?"
-    [[people_id.question]]
-        question = "Which super hero was you favourite when you were small? What can that say about you?"
-    [[people_id.question]]
-        question = "Now summarise the central themes from your previous answers."
+
+  [[people_id.question]]
+  question = "5 people that inspire you most in the world stand before you. Who are they and what is it about them that sparks something within you?"
+
+  [[people_id.question]]
+  question = "Who is someone in your life or in history whose life and work inspires and excites you? Why?"
+
+  [[people_id.question]]
+  question = "Who influenced your life most and why?"
+
+  [[people_id.question]]
+  question = "With which character in a book or movie did you relate well and why?"
+
+  [[people_id.question]]
+  question = "Which super hero was you favourite when you were small? What can that say about you?"
+
+  [[people_id.question]]
+  question = "Now summarise the central themes from your previous answers."
 
 #########################################
 # DREAMS
 ##############
 
 [dreams]
-    [[dreams.question]]
-        question = "When you were a child, what did you always dream of doing when you got older? What do they symbolise?"
-    [[dreams.question]]
-        question = "What are some childhood dreams or interests you were never able to fully explore but still find intriguing?"
-    [[dreams.question]]
-        question = "What difference do you want to make in the world? What legacy would you like to leave behind?"
-    [[dreams.question]]
-        question = "You inherit R100 million, how would it change your life? What would you do with your days?"
-    [[dreams.question]]
-        question = "When you are dead and gone, what would you like people to say about the way you lived your life?"
-    [[dreams.question]]
-        question = "What careers do you have wild dreams of having?"
-    [[dreams.question]]
-        question = "If someone were to pay all of your living costs and expenses for 2 years, what work would you pursue in that time?"
-    [[dreams.question]]
-        question = "If you were to change 3 things in the world for the greater good, what would they be?"
-    [[dreams.question]]
-        question = "What is it that you would regret not doing with your life, if you were to die tomorrow?"
-    [[dreams.question]]
-        question = "What piece of knowledge do you feel as though you would love to share with the world?"
-    [[dreams.question]]
-        question = "The person that loves you most in the whole world asks you what you need to be doing with your life in order to be really happy. How do you respond?"
-    [[dreams.question]]
-        question = "If you had 5 years left to live, what would you do?"
-    [[dreams.question]]
-        question = "How have your fears and limiting beliefs held you back from finding or pursuing your passion in the past?"
-    [[dreams.question]]
-        question = "Are there any people in your life preventing you from pursuing your passion? Who are they and how are they holding you back?"
-    [[dreams.question]]
-        question = "What is something (or several things) you'd really like to achieve before you die?"
-    [[dreams.question]]
-        question = "Now summarise the central themes from your previous answers."
+
+  [[dreams.question]]
+  question = "When you were a child, what did you always dream of doing when you got older? What do they symbolise?"
+
+  [[dreams.question]]
+  question = "What are some childhood dreams or interests you were never able to fully explore but still find intriguing?"
+
+  [[dreams.question]]
+  question = "What difference do you want to make in the world? What legacy would you like to leave behind?"
+
+  [[dreams.question]]
+  question = "You inherit R100 million, how would it change your life? What would you do with your days?"
+
+  [[dreams.question]]
+  question = "When you are dead and gone, what would you like people to say about the way you lived your life?"
+
+  [[dreams.question]]
+  question = "What careers do you have wild dreams of having?"
+
+  [[dreams.question]]
+  question = "If someone were to pay all of your living costs and expenses for 2 years, what work would you pursue in that time?"
+
+  [[dreams.question]]
+  question = "If you were to change 3 things in the world for the greater good, what would they be?"
+
+  [[dreams.question]]
+  question = "What is it that you would regret not doing with your life, if you were to die tomorrow?"
+
+  [[dreams.question]]
+  question = "What piece of knowledge do you feel as though you would love to share with the world?"
+
+  [[dreams.question]]
+  question = "The person that loves you most in the whole world asks you what you need to be doing with your life in order to be really happy. How do you respond?"
+
+  [[dreams.question]]
+  question = "If you had 5 years left to live, what would you do?"
+
+  [[dreams.question]]
+  question = "How have your fears and limiting beliefs held you back from finding or pursuing your passion in the past?"
+
+  [[dreams.question]]
+  question = "Are there any people in your life preventing you from pursuing your passion? Who are they and how are they holding you back?"
+
+  [[dreams.question]]
+  question = "What is something (or several things) you'd really like to achieve before you die?"
+
+  [[dreams.question]]
+  question = "Now summarise the central themes from your previous answers."
 
 #########################################
 # VALUES
 ##########################
 
 [values]
-    [[values.question]]
-        question = "What are your top  most deeply held core values?"
-    [[values.question]]
-        question = "How does your life currently support or reflect those values?"
-    [[values.question]]
-        question = "Which of your top values are you ignoring or not giving enough attention?"
-    [[values.question]]
-        question = "What values will you never compromise?"
-    [[values.question]]
-        question = "Which jobs would encompass your core values?"
-    [[values.question]]
-        question = "Now summarise the central themes from your previous answers."
+
+  [[values.question]]
+  question = "What are your top  most deeply held core values?"
+
+  [[values.question]]
+  question = "How does your life currently support or reflect those values?"
+
+  [[values.question]]
+  question = "Which of your top values are you ignoring or not giving enough attention?"
+
+  [[values.question]]
+  question = "What values will you never compromise?"
+
+  [[values.question]]
+  question = "Which jobs would encompass your core values?"
+
+  [[values.question]]
+  question = "Now summarise the central themes from your previous answers."
 
 #########################################
 # SPOKEN WORDS
 #######################
 
 [spoken_words]
-    [[spoken_words.question]]
-        question = "Things people say about you has a big impact on your life and often reveal a lot more than you think...\nFill these commonly spoken words below"
-    [[spoken_words.question]]
-        question = "Now summarise the central themes from your answer and type them below"
+
+  [[spoken_words.question]]
+  question = "Things people say about you has a big impact on your life and often reveal a lot more than you think...\nFill these commonly spoken words below"
+
+  [[spoken_words.question]]
+  question = "Now summarise the central themes from your answer and type them below"
 
 ####################################
 # SKILLS
 ###########
 
 [skills]
-    [[skills.question]]
-        question = "Administration"
-    [[skills.question]]
-        question = "Analyse"
-    [[skills.question]]
-        question = "Artistic"
-    [[skills.question]]
-        question = "Communicate"
-    [[skills.question]]
-        question = "Computers"
-    [[skills.question]]
-        question = "Control"
-    [[skills.question]]
-        question = "Counseling"
-    [[skills.question]]
-        question = "Creative"
-    [[skills.question]]
-        question = "Devision Making"
-    [[skills.question]]
-        question = "Empathy"
-    [[skills.question]]
-        question = "Entertaining"
-    [[skills.question]]
-        question = "Handwork"
-    [[skills.question]]
-        question = "Marketing"
-    [[skills.question]]
-        question = "Negotiate"
-    [[skills.question]]
-        question = "Numeracy"
-    [[skills.question]]
-        question = "Objectivity"
-    [[skills.question]]
-        question = "Organise"
-    [[skills.question]]
-        question = "Planning"
-    [[skills.question]]
-        question = "Playing Musical Instruments"
-    [[skills.question]]
-        question = "Practical"
-    [[skills.question]]
-        question = "Public Speaking"
-    [[skills.question]]
-        question = "Receptive for people"
-    [[skills.question]]
-        question = "Sharing"
-    [[skills.question]]
-        question = "Sport"
-    [[skills.question]]
-        question = "Strategic Planning"
-    [[skills.question]]
-        question = "Study"
-    [[skills.question]]
-        question = "Taking the lead"
-    [[skills.question]]
-        question = "Teaching"
-    [[skills.question]]
-        question = "Writing"
+
+  [[skills.question]]
+  question = "Administration"
+
+  [[skills.question]]
+  question = "Analyse"
+
+  [[skills.question]]
+  question = "Artistic"
+
+  [[skills.question]]
+  question = "Communicate"
+
+  [[skills.question]]
+  question = "Computers"
+
+  [[skills.question]]
+  question = "Control"
+
+  [[skills.question]]
+  question = "Counseling"
+
+  [[skills.question]]
+  question = "Creative"
+
+  [[skills.question]]
+  question = "Devision Making"
+
+  [[skills.question]]
+  question = "Empathy"
+
+  [[skills.question]]
+  question = "Entertaining"
+
+  [[skills.question]]
+  question = "Handwork"
+
+  [[skills.question]]
+  question = "Marketing"
+
+  [[skills.question]]
+  question = "Negotiate"
+
+  [[skills.question]]
+  question = "Numeracy"
+
+  [[skills.question]]
+  question = "Objectivity"
+
+  [[skills.question]]
+  question = "Organise"
+
+  [[skills.question]]
+  question = "Planning"
+
+  [[skills.question]]
+  question = "Playing Musical Instruments"
+
+  [[skills.question]]
+  question = "Practical"
+
+  [[skills.question]]
+  question = "Public Speaking"
+
+  [[skills.question]]
+  question = "Receptive for people"
+
+  [[skills.question]]
+  question = "Sharing"
+
+  [[skills.question]]
+  question = "Sport"
+
+  [[skills.question]]
+  question = "Strategic Planning"
+
+  [[skills.question]]
+  question = "Study"
+
+  [[skills.question]]
+  question = "Taking the lead"
+
+  [[skills.question]]
+  question = "Teaching"
+
+  [[skills.question]]
+  question = "Writing"
 
 ####################
 # PRIORITIES
@@ -917,71 +988,279 @@
   tooltip = "You like get do the things done. You like working hard to achieve your goals."
 
   ###############
-  # CAREER GUIDANCE
+  # CAREER ORIENTATION
   ######
 
   [career_orientation]
 
   [[career_orientation.question]]
   title = "Language & Communication"
-  options = ["Writing for a newspaper", "Doing translations", "Reading news reports on the radio or TV", "Writing stories or poetry", "Writing advertisements and scripts for TV, film and radio commercials"]
+  options = [
+    "Writing for a newspaper",
+    "Doing translations",
+    "Reading news reports on the radio or TV",
+    "Writing stories or poetry",
+    "Writing advertisements and scripts for TV, film and radio commercials"
+  ]
+
   [[career_orientation.question]]
   title = "Applied/Visual Arts"
-  options =["interested in this area, you would probably enjo","Taking photos for a magazine or newspaper","Drawing and designing buildings","Decorating the interior of houses","Creating works of art","Designing clothes"]
+  options = [
+    "interested in this area, you would probably enjo",
+    "Taking photos for a magazine or newspaper",
+    "Drawing and designing buildings",
+    "Decorating the interior of houses",
+    "Creating works of art",
+    "Designing clothes"
+  ]
+
   [[career_orientation.question]]
   title = "Performing Arts"
-  options =["Learning to play a musical instrument","Acting in a play or film","Dancing and singing in a musical","Directing a TV series or film","Selecting and playing popular CD's at a radio station"]
+  options = [
+    "Learning to play a musical instrument",
+    "Acting in a play or film",
+    "Dancing and singing in a musical",
+    "Directing a TV series or film",
+    "Selecting and playing popular CD's at a radio station"
+  ]
+
   [[career_orientation.question]]
   title = "Marketing & Direct Sales"
-  options =["Selling goods from door to door","Purchasing and selling anything","Making purchases on behalf of a shop or business","Studying the needs of consumers","Introducing consumers to new products"]
+  options = [
+    "Selling goods from door to door",
+    "Purchasing and selling anything",
+    "Making purchases on behalf of a shop or business",
+    "Studying the needs of consumers",
+    "Introducing consumers to new products"
+  ]
+
   [[career_orientation.question]]
   title = "Management & Planning"
-  options =["Supervising the activities of people","Influencing others to accept your point of view","Planning other people's work","Managing a big project or task","Acting as the leader of a group of people"]
+  options = [
+    "Supervising the activities of people",
+    "Influencing others to accept your point of view",
+    "Planning other people's work",
+    "Managing a big project or task",
+    "Acting as the leader of a group of people"
+  ]
+
   [[career_orientation.question]]
   title = "Clerical & Secretarial"
-  options =["Doing routine tasks","Typing business letters and reports","Filing documents","Receiving and sending off documents and parcels","Arranging appointment"]
+  options = [
+    "Doing routine tasks",
+    "Typing business letters and reports",
+    "Filing documents",
+    "Receiving and sending off documents and parcels",
+    "Arranging appointment"
+  ]
+
   [[career_orientation.question]]
   title = "Numerical & Financial Transactions"
-  options =["Working with figures most of the time","Keeping careful record of financial transactions","Checking the financial statements of a company","Drawing up the budget of a business","Keeping record of the costs of a shop"]
+  options = [
+    "Working with figures most of the time",
+    "Keeping careful record of financial transactions",
+    "Checking the financial statements of a company",
+    "Drawing up the budget of a business",
+    "Keeping record of the costs of a shop"
+  ]
+
   [[career_orientation.question]]
   title = "Nature (Plants & Animals)"
-  options =["Working on a farm with crops or cattle","Preparing a vegetable garden","Looking after animals","Working in a nursery","Trying to conserve the environment"]
+  options = [
+    "Working on a farm with crops or cattle",
+    "Preparing a vegetable garden",
+    "Looking after animals",
+    "Working in a nursery",
+    "Trying to conserve the environment"
+  ]
+
   [[career_orientation.question]]
   title = "Building & Construction"
-  options =["Planning and overseeing building projects","Preparing estimates of the costs involved in constructing a building","Tiling floors of buildings and houses","Building and repairing houses","Construction of big buildings and roads"]
+  options = [
+    "Planning and overseeing building projects",
+    "Preparing estimates of the costs involved in constructing a building",
+    "Tiling floors of buildings and houses",
+    "Building and repairing houses",
+    "Construction of big buildings and roads"
+  ]
+
   [[career_orientation.question]]
   title = "Manufacturing, Repairing and Servicing Machines"
-  options =["Fixing the engine of a motor car","Installing and repairing things that work with electricity","Mending broken things","Doing woodwork or other handwork","Using technical tools"]
+  options = [
+    "Fixing the engine of a motor car",
+    "Installing and repairing things that work with electricity",
+    "Mending broken things",
+    "Doing woodwork or other handwork",
+    "Using technical tools"
+  ]
+
   [[career_orientation.question]]
   title = "Engineering & Related Technologies"
-  options =["Designing mechanical equipment","Manufacturing and maintaining electrical/electronic equipment","Designing and manufacturing systems and components in the telecommunication area","Monitoring and operating instruments (e.g. electronic, mechanical etc.) and systems","Manufacturing and installing technical instruments"]
+  options = [
+    "Designing mechanical equipment",
+    "Manufacturing and maintaining electrical/electronic equipment",
+    "Designing and manufacturing systems and components in the telecommunication area",
+    "Monitoring and operating instruments (e.g. electronic, mechanical etc.) and systems",
+    "Manufacturing and installing technical instruments"
+  ]
+
   [[career_orientation.question]]
   title = "Information Technology/Computer Science"
-  options =["Writing computer programs","Developing data bases","Developing systems to solve problems with the help of computers","Designing and installing computer equipment","Design and implement computer systems"]
+  options = [
+    "Writing computer programs",
+    "Developing data bases",
+    "Developing systems to solve problems with the help of computers",
+    "Designing and installing computer equipment",
+    "Design and implement computer systems"
+  ]
+
   [[career_orientation.question]]
   title = "Natural Science & Mathematics"
-  options =["Conducting experiments in a science laboratory","Studying plants or animals","Using knowledge of maths and statistics in your work","Studying physical or chemistry science matters","Using a microscope"]
+  options = [
+    "Conducting experiments in a science laboratory",
+    "Studying plants or animals",
+    "Using knowledge of maths and statistics in your work",
+    "Studying physical or chemistry science matters",
+    "Using a microscope"
+  ]
+
   [[career_orientation.question]]
   title = "Health Science & Technology"
-  options =["Treating people with ailments or injuries","Mixing and preparing medicine","Studying the causes of diseases","Treating animals with ailments"]
+  options = [
+    "Treating people with ailments or injuries",
+    "Mixing and preparing medicine",
+    "Studying the causes of diseases",
+    "Treating animals with ailments"
+  ]
+
   [[career_orientation.question]]
   title = "Social & Economic Sciences"
-  options =["Studying the behavior of humans","Analysing and describing economic issues","Reading history books","Studying the culture and life style of human societies","Conducting public opinion surveys and interpreting the results"]
+  options = [
+    "Studying the behavior of humans",
+    "Analysing and describing economic issues",
+    "Reading history books",
+    "Studying the culture and life style of human societies",
+    "Conducting public opinion surveys and interpreting the results"
+  ]
+
   [[career_orientation.question]]
   title = "Law"
-  options =["Presenting cases in court","Speaking in public","Studying legislation documents","Identifying facts from irrelevant detail"]
+  options = [
+    "Presenting cases in court",
+    "Speaking in public",
+    "Studying legislation documents",
+    "Identifying facts from irrelevant detail"
+  ]
+
   [[career_orientation.question]]
   title = "Education & Social Services"
-  options =["Helping people with their problems","Looking after children","Doing voluntary work in poverty stricken communities","Attending to the spiritual needs of people"]
+  options = [
+    "Helping people with their problems",
+    "Looking after children",
+    "Doing voluntary work in poverty stricken communities",
+    "Attending to the spiritual needs of people"
+  ]
+
   [[career_orientation.question]]
   title = "Nursing & Caring"
-  options =["Caring for the sick","Giving first aid to people","Working as a nurse in a hospital","Assisting physically disabled people to function independently","Attending to the needs of babies or small children"]
+  options = [
+    "Caring for the sick",
+    "Giving first aid to people",
+    "Working as a nurse in a hospital",
+    "Assisting physically disabled people to function independently",
+    "Attending to the needs of babies or small children"
+  ]
+
   [[career_orientation.question]]
   title = "Sport"
-  options =["Training people to play sport","Demonstrating exercises to help people keep fit","Organizing and coordinating sports events","Officiating at a sport event (rugby, soccer, tennis, etc.)","Taking part in competitive sports events to become a professional"]
+  options = [
+    "Training people to play sport",
+    "Demonstrating exercises to help people keep fit",
+    "Organizing and coordinating sports events",
+    "Officiating at a sport event (rugby, soccer, tennis, etc.)",
+    "Taking part in competitive sports events to become a professional"
+  ]
+
   [[career_orientation.question]]
   title = "Law Enforcement & Protection Services"
-  options =["Protecting the country","Maintaining law and order","Ensuring that people obey the traffic rules","Working as a guard at a prison","Protecting buildings against fire"]
+  options = [
+    "Protecting the country",
+    "Maintaining law and order",
+    "Ensuring that people obey the traffic rules",
+    "Working as a guard at a prison",
+    "Protecting buildings against fire"
+  ]
+
   [[career_orientation.question]]
   title = "Personal Services"
-  options =["Looking after the needs and comfort of passengers in an airplane","Rendering catering services","Offering and maintaining cleaning services for big companies","Transporting people by bus or car","Running a guest house"]
+  options = [
+    "Looking after the needs and comfort of passengers in an airplane",
+    "Rendering catering services",
+    "Offering and maintaining cleaning services for big companies",
+    "Transporting people by bus or car",
+    "Running a guest house"
+  ]
+#######################
+# MBTI INFO
+#############
+[mbti_info]
+
+  [[mbti_info.type]]
+  key = "E"
+  description_1 = "Outward focus, communication, energy"
+  description_2 = "Direct involvement and implementation"
+
+  [[mbti_info.type]]
+  key = "I"
+  description_1 = "Thinkers, concepts, writing, alone time"
+  description_2 = "Direct or indirect involvement and implementation with enough time alone"
+
+  [[mbti_info.type]]
+  key = "N"
+  description_1 = "Innovative, holistic, see new possibilities"
+  description_2 = ""
+
+  [[mbti_info.type]]
+  key = "S"
+  description_1 = "Practical and detail orientated"
+  description_2 = ""
+
+  [[mbti_info.type]]
+  key = "F"
+  description_1 = "eople oriented, sympathetic, personal"
+  description_2 = ""
+
+  [[mbti_info.type]]
+  key = "T"
+  description_1 = "Objective, analytical, logical"
+  description_2 = ""
+
+  [[mbti_info.type]]
+  key = "P"
+  description_1 = "Flexible, spontaneous, philosophical"
+  description_2 = "Spontaneous and flexible environment"
+
+  [[mbti_info.type]]
+  key = "J"
+  description_1 = "Order, control, structure"
+  description_2 = "Organized, structured and conclusive environment"
+
+  [[mbti_info.type]]
+  key = "NF"
+  description_1 = ""
+  description_2 = "You will be innovative in the development of people on a more personal basis"
+
+  [[mbti_info.type]]
+  key = "NT"
+  description_1 = ""
+  description_2 = "You will be innovative in some of the following: development of systems, patents, organizations, management or people on a less personal level"
+
+  [[mbti_info.type]]
+  key = "SF"
+  description_1 = ""
+  description_2 = "You will want to help people by working hands on and in a practical manner with them"
+
+  [[mbti_info.type]]
+  key = "ST"
+  description_1 = ""
+  description_2 = "You will want to manage or bring practical solutions to systems, organizations, management or people on a less personal level"

--- a/src/components/life_keys_info_panel.cpp
+++ b/src/components/life_keys_info_panel.cpp
@@ -1,0 +1,119 @@
+#include "life_keys_info_panel.hpp"
+
+LifeKeysInfoPanel::LifeKeysInfoPanel(wxWindow* parent, wxWindowID id,
+                                     const wxPoint& pos, const wxSize& size,
+                                     int64_t style)
+    : wxPanel(parent, id, pos, size, style) {
+  DoLayout();
+}
+
+void LifeKeysInfoPanel::SetLifeKeyData(
+    std::shared_ptr<cpptoml::table> gui_state) {
+  auto external_panel_table = gui_state->get_table("external");
+  if (external_panel_table) {
+    auto life_keys_table = external_panel_table->get_table("life_keys");
+    if (life_keys_table) {
+      auto type_array = life_keys_table->get_table_array("type");
+      if (type_array) {
+        for (const auto& type : *type_array) {
+          auto key = type->get_as<std::string>("key");
+          auto title = type->get_as<std::string>("title");
+          auto love_to_do =
+              type->get_array_of<std::string>("things_they_love_to_do");
+
+          struct LifeKey life_key;
+          if (key) {
+            life_key.key = *key;
+            wxLogDebug(_(*key));
+          }
+          if (title) {
+            life_key.title = *title;
+            wxLogDebug(_(*title));
+          }
+          if (love_to_do) {
+            for (const std::string element : *love_to_do) {
+              wxLogDebug(_(element));
+              life_key.love_to_dos.push_back(element);
+            }
+          }
+
+          life_keys_.push_back(life_key);
+        }
+      }
+    }
+  }
+}
+
+struct LifeKeysInfoPanel::LifeKey LifeKeysInfoPanel::GetLifeKeyDataByKey(
+    std::string key) {
+  for (size_t i = 0; i < life_keys_.size(); i++) {
+    if (life_keys_.at(i).key.compare(key) == 0) {
+      return life_keys_.at(i);
+    }
+  }
+
+  struct LifeKey error;
+  error.key = "Error";
+
+  return error;
+}
+
+void LifeKeysInfoPanel::CreateLifeKeysPanel() {
+  if (panel_life_keys_ != NULL) {
+    sizer_->Detach(panel_life_keys_);
+    delete panel_life_keys_;
+  }
+
+  panel_life_keys_ = new wxPanel(sizer_->GetStaticBox(), wxID_ANY);
+  sizer_life_keys_ = new wxBoxSizer(wxVERTICAL);
+
+  panel_life_keys_->SetSizer(sizer_life_keys_);
+  sizer_->Add(panel_life_keys_, 0, wxEXPAND | wxALL, 6);
+}
+
+void LifeKeysInfoPanel::SetLifeKeys(std::vector<std::string> life_keys) {
+  active_life_keys_ = life_keys;
+
+  CreateLifeKeysPanel();
+
+  for (size_t i = 0; i < life_keys.size(); i++) {
+    struct LifeKey life_key_data = GetLifeKeyDataByKey(life_keys.at(i));
+    if (life_key_data.key.compare(life_keys.at(i)) == 0) {
+      wxLogDebug(_("Found life key") + _(life_keys.at(i)));
+
+      wxStaticText* label_title =
+          new wxStaticText(panel_life_keys_, wxID_ANY, life_key_data.title);
+      wxFont font_title = label_title->GetFont();
+      font_title.SetPointSize(16);
+      font_title.Bold();
+      label_title->SetFont(font_title);
+      sizer_life_keys_->Add(label_title, 0, 0, 0);
+
+      sizer_life_keys_->AddSpacer(0);
+
+      for (size_t j = 0; j < life_key_data.love_to_dos.size(); j++) {
+        wxStaticText* label_love =
+            new wxStaticText(panel_life_keys_, wxID_ANY,
+                             _("- ") + _(life_key_data.love_to_dos.at(j)));
+
+        sizer_life_keys_->Add(label_love, 0, 0, 0);
+      }
+
+      sizer_life_keys_->AddSpacer(15);
+    } else {
+      wxLogWarning(_("Invalid life key:") + _(life_keys.at(i)));
+    }
+  }
+
+  sizer_->Fit(this);
+  Layout();
+}
+
+void LifeKeysInfoPanel::DoLayout() {
+  sizer_ = new wxStaticBoxSizer(wxVERTICAL, this, "Life Keys");
+
+  CreateLifeKeysPanel();
+
+  this->SetSizer(sizer_);
+  Layout();
+}

--- a/src/components/life_keys_info_panel.cpp
+++ b/src/components/life_keys_info_panel.cpp
@@ -216,7 +216,7 @@ void LifeKeysInfoPanel::DoLayout() {
   sizer_ = new wxStaticBoxSizer(wxVERTICAL, this, "Life Keys");
 
   sizer_choice_boxes_ = new wxBoxSizer(wxHORIZONTAL);
-  sizer_->Add(sizer_choice_boxes_, 0, 0, 0);
+  sizer_->Add(sizer_choice_boxes_, 0, wxALL, 6);
 
   CreateLifeKeysPanel();
 

--- a/src/components/life_keys_info_panel.hpp
+++ b/src/components/life_keys_info_panel.hpp
@@ -17,7 +17,7 @@ class LifeKeysInfoPanel : public wxPanel {
   LifeKeysInfoPanel(wxWindow* parent, wxWindowID id,
                     const wxPoint& pos = wxDefaultPosition,
                     const wxSize& size = wxDefaultSize, int64_t style = 0);
-  ~LifeKeysInfoPanel(){};
+  ~LifeKeysInfoPanel() { delete life_keys_keys_; };
 
   /**
    * Recreate the internal layout based on the given keys
@@ -36,6 +36,9 @@ class LifeKeysInfoPanel : public wxPanel {
    */
   void SetLifeKeyData(std::shared_ptr<cpptoml::table>(gui_state));
 
+  void OnLifeKeyChange(wxCommandEvent& event);  // NOLINT
+  std::vector<std::string> GetLifeKeys();
+
   struct LifeKey {
     std::string key;
     std::string title;
@@ -45,10 +48,15 @@ class LifeKeysInfoPanel : public wxPanel {
  private:
   void DoLayout();
   void CreateLifeKeysPanel();
+  void CreateChoiceBoxes(wxWindow* parent, wxSizer* injection_sizer,
+                                wxArrayString* keys);
   struct LifeKey GetLifeKeyDataByKey(std::string key);
   std::vector<std::string> active_life_keys_;
   std::vector<struct LifeKey> life_keys_;
+  wxArrayString* life_keys_keys_ = NULL;
+  wxChoice* choice_boxes_keys_[3];
   wxPanel* panel_life_keys_ = NULL;
+  wxBoxSizer* sizer_choice_boxes_ = NULL;
   wxBoxSizer* sizer_life_keys_ = NULL;
   wxStaticBoxSizer* sizer_ = NULL;
 };

--- a/src/components/life_keys_info_panel.hpp
+++ b/src/components/life_keys_info_panel.hpp
@@ -23,6 +23,17 @@ class LifeKeysInfoPanel : public wxPanel {
    * Recreate the internal layout based on the given keys
    */
   void SetLifeKeys(std::vector<std::string> life_keys);
+
+  /**
+   * TOML SPEC:
+   * [external.life_keys]
+   *   [[external.life_keys.type]]
+   *     key = ""
+   *     title = ""
+   *     characteristics = [""]
+   *     work_environments = [""]
+   *     things_they_love_to_do = [""]
+   */
   void SetLifeKeyData(std::shared_ptr<cpptoml::table>(gui_state));
 
   struct LifeKey {

--- a/src/components/life_keys_info_panel.hpp
+++ b/src/components/life_keys_info_panel.hpp
@@ -1,0 +1,45 @@
+#ifndef COMPONENTS_LIFE_KEYS_INFO_PANEL_HPP_
+#define COMPONENTS_LIFE_KEYS_INFO_PANEL_HPP_
+
+#include <wx/wxprec.h>
+#ifndef WX_PRECOMP
+#include <wx/wx.h>
+#endif
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "include/cpptoml.h"
+
+class LifeKeysInfoPanel : public wxPanel {
+ public:
+  LifeKeysInfoPanel(wxWindow* parent, wxWindowID id,
+                    const wxPoint& pos = wxDefaultPosition,
+                    const wxSize& size = wxDefaultSize, int64_t style = 0);
+  ~LifeKeysInfoPanel(){};
+
+  /**
+   * Recreate the internal layout based on the given keys
+   */
+  void SetLifeKeys(std::vector<std::string> life_keys);
+  void SetLifeKeyData(std::shared_ptr<cpptoml::table>(gui_state));
+
+  struct LifeKey {
+    std::string key;
+    std::string title;
+    std::vector<std::string> love_to_dos;
+  };
+
+ private:
+  void DoLayout();
+  void CreateLifeKeysPanel();
+  struct LifeKey GetLifeKeyDataByKey(std::string key);
+  std::vector<std::string> active_life_keys_;
+  std::vector<struct LifeKey> life_keys_;
+  wxPanel* panel_life_keys_ = NULL;
+  wxBoxSizer* sizer_life_keys_ = NULL;
+  wxStaticBoxSizer* sizer_ = NULL;
+};
+
+#endif  // COMPONENTS_LIFE_KEYS_INFO_PANEL_HPP_

--- a/src/components/mbti_info_panel.cpp
+++ b/src/components/mbti_info_panel.cpp
@@ -209,9 +209,9 @@ void MbtiInfoPanel::DoLayout() {
   descriptions_2_[1] = ext_desc2;
   descriptions_2_[2] = ext_desc3;
 
-  sizer->Add(ext_desc1, wxGBPosition(1, 2), wxGBSpan(1, 1), 0, 0);
-  sizer->Add(ext_desc2, wxGBPosition(3, 2), wxGBSpan(2, 1), wxALIGN_CENTER, 0);
-  sizer->Add(ext_desc3, wxGBPosition(6, 2), wxGBSpan(1, 1), 0, 0);
+  sizer->Add(ext_desc1, wxGBPosition(1, 2), wxGBSpan(1, 1), wxLEFT, 20);
+  sizer->Add(ext_desc2, wxGBPosition(3, 2), wxGBSpan(2, 1), wxLEFT, 20);
+  sizer->Add(ext_desc3, wxGBPosition(6, 2), wxGBSpan(1, 1), wxLEFT, 20);
 
   this->SetSizer(sizer);
   sizer->Fit(this);

--- a/src/components/mbti_info_panel.cpp
+++ b/src/components/mbti_info_panel.cpp
@@ -147,22 +147,22 @@ void MbtiInfoPanel::DoLayout() {
   wxStaticLine* line2 = new wxStaticLine(this);
   wxStaticLine* line3 = new wxStaticLine(this);
 
-  wxStaticText* mbti1 = new wxStaticText(this, wxID_ANY, "I");
-  wxStaticText* mbti2 = new wxStaticText(this, wxID_ANY, "S");
-  wxStaticText* mbti3 = new wxStaticText(this, wxID_ANY, "T");
-  wxStaticText* mbti4 = new wxStaticText(this, wxID_ANY, "J");
+  wxStaticText* mbti1 = new wxStaticText(this, wxID_ANY, wxEmptyString);
+  wxStaticText* mbti2 = new wxStaticText(this, wxID_ANY, wxEmptyString);
+  wxStaticText* mbti3 = new wxStaticText(this, wxID_ANY, wxEmptyString);
+  wxStaticText* mbti4 = new wxStaticText(this, wxID_ANY, wxEmptyString);
 
-  wxStaticText* desc1 = new wxStaticText(this, wxID_ANY, "Good, caring, elola");
-  wxStaticText* desc2 = new wxStaticText(this, wxID_ANY, "Fast, Smart, Skiw");
-  wxStaticText* desc3 = new wxStaticText(this, wxID_ANY, "Skiddy Python nuc");
-  wxStaticText* desc4 = new wxStaticText(this, wxID_ANY, "D U know da wey");
+  wxStaticText* desc1 = new wxStaticText(this, wxID_ANY, wxEmptyString);
+  wxStaticText* desc2 = new wxStaticText(this, wxID_ANY, wxEmptyString);
+  wxStaticText* desc3 = new wxStaticText(this, wxID_ANY, wxEmptyString);
+  wxStaticText* desc4 = new wxStaticText(this, wxID_ANY, wxEmptyString);
 
   wxStaticText* ext_desc1 =
-      new wxStaticText(this, wxID_ANY, "jksdkfjh sjs s d d d ds ");
+      new wxStaticText(this, wxID_ANY, wxEmptyString);
   wxStaticText* ext_desc2 =
-      new wxStaticText(this, wxID_ANY, "gh4ghth 23ersed reg");
+      new wxStaticText(this, wxID_ANY, wxEmptyString);
   wxStaticText* ext_desc3 = new wxStaticText(
-      this, wxID_ANY, "jjk  5y y ytyrtytry rhfg e ty 4 khk  jfh dg rghfh");
+      this, wxID_ANY, wxEmptyString);
 
   const int kFlags = wxALL | wxALIGN_CENTER;
   const int kBorder = 6;

--- a/src/components/mbti_info_panel.cpp
+++ b/src/components/mbti_info_panel.cpp
@@ -1,6 +1,7 @@
 #include "mbti_info_panel.hpp"
 
 #include <memory>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -9,4 +10,211 @@ MbtiInfoPanel::MbtiInfoPanel(wxWindow* parent, wxWindowID id,
                              int64_t style)
     : wxPanel(parent, id, pos, size, style) {
   DoLayout();
+}
+
+void MbtiInfoPanel::SetMbti(std::string mbti) {
+  wxLogDebug("MbtiInfoPanel::SetMbti() START");
+
+  if (mbti.length() != 4) {
+    wxLogWarning("Invalid MBTI string");
+  }
+
+  mbti_ = mbti;
+  struct MbtiInfoPanel::MbtiInfo mbti_info = GetMbtiInfo(mbti);
+
+  for (size_t i = 0; i < 4; i++) {
+    labels_mbti_[i]->SetLabel(mbti.substr(i, 1));
+    descriptions_1_[i]->SetLabel(mbti_info.descriptions_1.at(i));
+
+    if (i < 3) {
+      descriptions_2_[i]->SetLabel(mbti_info.descriptions_2.at(i));
+    }
+  }
+
+  for (size_t i = 0; i < 4; i++) {
+    descriptions_1_[i]->Wrap(DESC_1_WRAP_PX);
+    if (i < 3) {
+      descriptions_2_[i]->Wrap(DESC_2_WRAP_PX);
+    }
+  }
+
+  this->Layout();
+}
+
+void MbtiInfoPanel::SetMbtiInfoData(std::shared_ptr<cpptoml::table> gui_state) {
+  wxLogDebug("MbtiInfoPanel::SetMbtiInfoData() START");
+  auto mbti_table = gui_state->get_table("mbti_info");
+
+  if (mbti_table) {
+    struct MbtiInfoPanel::MbtiEntry mbti_entry;
+
+    auto type_array = mbti_table->get_table_array("type");
+    if (type_array) {
+      for (const auto& type_table : *type_array) {
+        auto key = type_table->get_as<std::string>("key");
+        if (key) {
+          mbti_entry.key = *key;
+        } else {
+          wxLogWarning("Could not find key 'key' on [[mbti_info.type]]");
+        }
+
+        auto desc1 = type_table->get_as<std::string>("description_1");
+        if (desc1) {
+          mbti_entry.desc1 = *desc1;
+        } else {
+          wxLogWarning(
+              "Could not find key 'description_2' on [[mbti_info.type]]");
+        }
+
+        auto desc2 = type_table->get_as<std::string>("description_2");
+        if (desc2) {
+          mbti_entry.desc2 = *desc2;
+        } else {
+          wxLogWarning(
+              "Could not find key 'description_2' on [[mbti_info.type]]");
+        }
+
+        mbti_entries_.push_back(mbti_entry);
+      }
+    }
+  } else {
+    wxLogWarning("Could not find table 'mbti_info' in GUI config");
+  }
+}
+
+struct MbtiInfoPanel::MbtiEntry MbtiInfoPanel::GetMbtiEntry(std::string key) {
+  for (size_t i = 0; i < mbti_entries_.size(); i++) {
+    if (mbti_entries_.at(i).key.compare(key) == 0) {
+      return mbti_entries_.at(i);
+    }
+  }
+
+  struct MbtiInfoPanel::MbtiEntry error;
+  error.key = "Error";
+
+  wxLogWarning(_("Could not find mbti key " + key));
+  return error;
+}
+
+struct MbtiInfoPanel::MbtiInfo MbtiInfoPanel::GetMbtiInfo(std::string mbti) {
+  wxLogDebug("MbtiInfoPanel::GetMbtiInfo() START");
+  struct MbtiInfoPanel::MbtiInfo mbti_info;
+
+  // Get description 1
+  for (size_t i = 0; i < 4; i++) {
+    std::stringstream ss;
+    ss << mbti.at(i);
+    std::string mbti_letter = "";
+    ss >> mbti_letter;
+
+    struct MbtiEntry entry = GetMbtiEntry(mbti_letter);
+    mbti_info.descriptions_1.push_back(entry.desc1);
+  }
+
+  // First desc2
+  struct MbtiEntry entry = GetMbtiEntry(mbti.substr(0, 1));
+  mbti_info.descriptions_2.push_back(entry.desc2);
+
+  // Middle desc2
+  std::string long_key = "";
+  long_key = mbti.substr(1, 2);
+  wxLogDebug(_(long_key));
+
+  for (size_t k = 0; k < mbti_entries_.size(); k++) {
+    if (mbti_entries_.at(k).key.compare(long_key) == 0) {
+      mbti_info.descriptions_2.push_back(mbti_entries_.at(k).desc2);
+      break;
+    }
+  }
+
+  // Last desc2
+  entry = GetMbtiEntry(mbti.substr(3, 1));
+  mbti_info.descriptions_2.push_back(entry.desc2);
+
+  if (mbti_info.descriptions_1.size() != 4 ||
+      mbti_info.descriptions_2.size() != 3) {
+    wxLogWarning(
+        "Could not parse MBTI info. Error on [mbti_info] (most likely)");
+  }
+
+  return mbti_info;
+}
+
+void MbtiInfoPanel::DoLayout() {
+  wxGridBagSizer* sizer = new wxGridBagSizer(0, 0);
+
+  wxStaticLine* line1 = new wxStaticLine(this);
+  wxStaticLine* line2 = new wxStaticLine(this);
+  wxStaticLine* line3 = new wxStaticLine(this);
+
+  wxStaticText* mbti1 = new wxStaticText(this, wxID_ANY, "I");
+  wxStaticText* mbti2 = new wxStaticText(this, wxID_ANY, "S");
+  wxStaticText* mbti3 = new wxStaticText(this, wxID_ANY, "T");
+  wxStaticText* mbti4 = new wxStaticText(this, wxID_ANY, "J");
+
+  wxStaticText* desc1 = new wxStaticText(this, wxID_ANY, "Good, caring, elola");
+  wxStaticText* desc2 = new wxStaticText(this, wxID_ANY, "Fast, Smart, Skiw");
+  wxStaticText* desc3 = new wxStaticText(this, wxID_ANY, "Skiddy Python nuc");
+  wxStaticText* desc4 = new wxStaticText(this, wxID_ANY, "D U know da wey");
+
+  wxStaticText* ext_desc1 =
+      new wxStaticText(this, wxID_ANY, "jksdkfjh sjs s d d d ds ");
+  wxStaticText* ext_desc2 =
+      new wxStaticText(this, wxID_ANY, "gh4ghth 23ersed reg");
+  wxStaticText* ext_desc3 = new wxStaticText(
+      this, wxID_ANY, "jjk  5y y ytyrtytry rhfg e ty 4 khk  jfh dg rghfh");
+
+  const int kFlags = wxALL | wxALIGN_CENTER;
+  const int kBorder = 6;
+
+  sizer->Add(line1, wxGBPosition(0, 0), wxGBSpan(1, 3), wxEXPAND, 0);
+  sizer->Add(line2, wxGBPosition(2, 0), wxGBSpan(1, 3), wxEXPAND, 0);
+  sizer->Add(line3, wxGBPosition(5, 0), wxGBSpan(1, 3), wxEXPAND, 0);
+
+  sizer->Add(mbti1, wxGBPosition(1, 0), wxGBSpan(1, 1), kFlags, kBorder);
+  sizer->Add(mbti2, wxGBPosition(3, 0), wxGBSpan(1, 1), kFlags, kBorder);
+  sizer->Add(mbti3, wxGBPosition(4, 0), wxGBSpan(1, 1), kFlags, kBorder);
+  sizer->Add(mbti4, wxGBPosition(6, 0), wxGBSpan(1, 1), kFlags, kBorder);
+
+  const int kDescFlags = wxALL | wxALIGN_LEFT;
+  const int kDescBorder = 6;
+
+  sizer->Add(desc1, wxGBPosition(1, 1), wxGBSpan(1, 1), kDescFlags,
+             kDescBorder);
+  sizer->Add(desc2, wxGBPosition(3, 1), wxGBSpan(1, 1), kDescFlags,
+             kDescBorder);
+  sizer->Add(desc3, wxGBPosition(4, 1), wxGBSpan(1, 1), kDescFlags,
+             kDescBorder);
+  sizer->Add(desc4, wxGBPosition(6, 1), wxGBSpan(1, 1), kDescFlags,
+             kDescBorder);
+
+  labels_mbti_[0] = mbti1;
+  labels_mbti_[1] = mbti2;
+  labels_mbti_[2] = mbti3;
+  labels_mbti_[3] = mbti4;
+
+  for (size_t i = 0; i < 4; i++) {
+    wxFont font = labels_mbti_[i]->GetFont();
+    font.SetPointSize(16);
+    font.MakeBold();
+    labels_mbti_[i]->SetFont(font);
+  }
+
+  descriptions_1_[0] = desc1;
+  descriptions_1_[1] = desc2;
+  descriptions_1_[2] = desc3;
+  descriptions_1_[3] = desc4;
+
+  descriptions_2_[0] = ext_desc1;
+  descriptions_2_[1] = ext_desc2;
+  descriptions_2_[2] = ext_desc3;
+
+  sizer->Add(ext_desc1, wxGBPosition(1, 2), wxGBSpan(1, 1), 0, 0);
+  sizer->Add(ext_desc2, wxGBPosition(3, 2), wxGBSpan(2, 1), wxALIGN_CENTER, 0);
+  sizer->Add(ext_desc3, wxGBPosition(6, 2), wxGBSpan(1, 1), 0, 0);
+
+  this->SetSizer(sizer);
+  sizer->Fit(this);
+
+  Layout();
 }

--- a/src/components/mbti_info_panel.cpp
+++ b/src/components/mbti_info_panel.cpp
@@ -242,6 +242,7 @@ void MbtiInfoPanel::OnMbtiChange(wxCommandEvent& event) {
   }
 
   sizer_root_->Fit(this);
+  this->GetParent()->Layout();
 }
 
 void MbtiInfoPanel::AddMbtiTuple(std::vector<wxArrayString>* source_vector,

--- a/src/components/mbti_info_panel.cpp
+++ b/src/components/mbti_info_panel.cpp
@@ -10,6 +10,7 @@ MbtiInfoPanel::MbtiInfoPanel(wxWindow* parent, wxWindowID id,
                              int64_t style)
     : wxPanel(parent, id, pos, size, style) {
   DoLayout();
+  this->SetBackgroundColour(wxColour(20, 0, 0));
 }
 
 void MbtiInfoPanel::SetMbti(std::string mbti) {
@@ -39,6 +40,7 @@ void MbtiInfoPanel::SetMbti(std::string mbti) {
   }
 
   this->Layout();
+  this->Fit();
 }
 
 void MbtiInfoPanel::SetMbtiInfoData(std::shared_ptr<cpptoml::table> gui_state) {
@@ -141,7 +143,7 @@ struct MbtiInfoPanel::MbtiInfo MbtiInfoPanel::GetMbtiInfo(std::string mbti) {
 }
 
 void MbtiInfoPanel::DoLayout() {
-  wxGridBagSizer* sizer = new wxGridBagSizer(0, 0);
+  sizer_ = new wxGridBagSizer(0, 0);
 
   wxStaticLine* line1 = new wxStaticLine(this);
   wxStaticLine* line2 = new wxStaticLine(this);
@@ -157,36 +159,33 @@ void MbtiInfoPanel::DoLayout() {
   wxStaticText* desc3 = new wxStaticText(this, wxID_ANY, wxEmptyString);
   wxStaticText* desc4 = new wxStaticText(this, wxID_ANY, wxEmptyString);
 
-  wxStaticText* ext_desc1 =
-      new wxStaticText(this, wxID_ANY, wxEmptyString);
-  wxStaticText* ext_desc2 =
-      new wxStaticText(this, wxID_ANY, wxEmptyString);
-  wxStaticText* ext_desc3 = new wxStaticText(
-      this, wxID_ANY, wxEmptyString);
+  wxStaticText* ext_desc1 = new wxStaticText(this, wxID_ANY, wxEmptyString);
+  wxStaticText* ext_desc2 = new wxStaticText(this, wxID_ANY, wxEmptyString);
+  wxStaticText* ext_desc3 = new wxStaticText(this, wxID_ANY, wxEmptyString);
 
   const int kFlags = wxALL | wxALIGN_CENTER;
   const int kBorder = 6;
 
-  sizer->Add(line1, wxGBPosition(0, 0), wxGBSpan(1, 3), wxEXPAND, 0);
-  sizer->Add(line2, wxGBPosition(2, 0), wxGBSpan(1, 3), wxEXPAND, 0);
-  sizer->Add(line3, wxGBPosition(5, 0), wxGBSpan(1, 3), wxEXPAND, 0);
+  sizer_->Add(line1, wxGBPosition(0, 0), wxGBSpan(1, 3), wxEXPAND, 0);
+  sizer_->Add(line2, wxGBPosition(2, 0), wxGBSpan(1, 3), wxEXPAND, 0);
+  sizer_->Add(line3, wxGBPosition(5, 0), wxGBSpan(1, 3), wxEXPAND, 0);
 
-  sizer->Add(mbti1, wxGBPosition(1, 0), wxGBSpan(1, 1), kFlags, kBorder);
-  sizer->Add(mbti2, wxGBPosition(3, 0), wxGBSpan(1, 1), kFlags, kBorder);
-  sizer->Add(mbti3, wxGBPosition(4, 0), wxGBSpan(1, 1), kFlags, kBorder);
-  sizer->Add(mbti4, wxGBPosition(6, 0), wxGBSpan(1, 1), kFlags, kBorder);
+  sizer_->Add(mbti1, wxGBPosition(1, 0), wxGBSpan(1, 1), kFlags, kBorder);
+  sizer_->Add(mbti2, wxGBPosition(3, 0), wxGBSpan(1, 1), kFlags, kBorder);
+  sizer_->Add(mbti3, wxGBPosition(4, 0), wxGBSpan(1, 1), kFlags, kBorder);
+  sizer_->Add(mbti4, wxGBPosition(6, 0), wxGBSpan(1, 1), kFlags, kBorder);
 
   const int kDescFlags = wxALL | wxALIGN_LEFT;
   const int kDescBorder = 6;
 
-  sizer->Add(desc1, wxGBPosition(1, 1), wxGBSpan(1, 1), kDescFlags,
-             kDescBorder);
-  sizer->Add(desc2, wxGBPosition(3, 1), wxGBSpan(1, 1), kDescFlags,
-             kDescBorder);
-  sizer->Add(desc3, wxGBPosition(4, 1), wxGBSpan(1, 1), kDescFlags,
-             kDescBorder);
-  sizer->Add(desc4, wxGBPosition(6, 1), wxGBSpan(1, 1), kDescFlags,
-             kDescBorder);
+  sizer_->Add(desc1, wxGBPosition(1, 1), wxGBSpan(1, 1), kDescFlags,
+              kDescBorder);
+  sizer_->Add(desc2, wxGBPosition(3, 1), wxGBSpan(1, 1), kDescFlags,
+              kDescBorder);
+  sizer_->Add(desc3, wxGBPosition(4, 1), wxGBSpan(1, 1), kDescFlags,
+              kDescBorder);
+  sizer_->Add(desc4, wxGBPosition(6, 1), wxGBSpan(1, 1), kDescFlags,
+              kDescBorder);
 
   labels_mbti_[0] = mbti1;
   labels_mbti_[1] = mbti2;
@@ -209,12 +208,11 @@ void MbtiInfoPanel::DoLayout() {
   descriptions_2_[1] = ext_desc2;
   descriptions_2_[2] = ext_desc3;
 
-  sizer->Add(ext_desc1, wxGBPosition(1, 2), wxGBSpan(1, 1), wxLEFT, 20);
-  sizer->Add(ext_desc2, wxGBPosition(3, 2), wxGBSpan(2, 1), wxLEFT, 20);
-  sizer->Add(ext_desc3, wxGBPosition(6, 2), wxGBSpan(1, 1), wxLEFT, 20);
+  sizer_->Add(ext_desc1, wxGBPosition(1, 2), wxGBSpan(1, 1), wxLEFT, 20);
+  sizer_->Add(ext_desc2, wxGBPosition(3, 2), wxGBSpan(2, 1), wxLEFT, 20);
+  sizer_->Add(ext_desc3, wxGBPosition(6, 2), wxGBSpan(1, 1), wxLEFT, 20);
 
-  this->SetSizer(sizer);
-  sizer->Fit(this);
+  this->SetSizer(sizer_);
 
   Layout();
 }

--- a/src/components/mbti_info_panel.cpp
+++ b/src/components/mbti_info_panel.cpp
@@ -1,0 +1,2 @@
+#include "mbti_info_panel.hpp"
+

--- a/src/components/mbti_info_panel.cpp
+++ b/src/components/mbti_info_panel.cpp
@@ -10,7 +10,20 @@ MbtiInfoPanel::MbtiInfoPanel(wxWindow* parent, wxWindowID id,
                              int64_t style)
     : wxPanel(parent, id, pos, size, style) {
   DoLayout();
-  this->SetBackgroundColour(wxColour(20, 0, 0));
+}
+
+void MbtiInfoPanel::SetMbti(std::vector<std::string> mbti) {
+  std::string result = "";
+
+  for (size_t i = 0; i < 4; i++) {
+    if (mbti.at(i).compare(" ") != 0) {
+      result += mbti.at(i);
+    } else {
+      result += " ";
+    }
+  }
+
+  SetMbti(result);
 }
 
 void MbtiInfoPanel::SetMbti(std::string mbti) {
@@ -23,15 +36,31 @@ void MbtiInfoPanel::SetMbti(std::string mbti) {
   mbti_ = mbti;
   struct MbtiInfoPanel::MbtiInfo mbti_info = GetMbtiInfo(mbti);
 
+  wxLogDebug("MbtiInfoPanel::SetMbti() 1");
   for (size_t i = 0; i < 4; i++) {
+    wxLogDebug(_("MbtiInfoPanel::SetMbti() letter: " + std::to_string(i)));
+    for (size_t j = 0; j < 4; j++) {
+      const int selection =
+          choice_boxes_mbti_[j]->FindString(mbti.substr(i, 1));
+      if (selection != wxNOT_FOUND) {
+        wxLogDebug("MbtiInfoPanel::SetMbti() Setting Choice");
+        choice_boxes_mbti_[j]->SetSelection(selection);
+      }
+    }
+
+    wxLogDebug("MbtiInfoPanel::SetMbti() Setting label and desc1");
     labels_mbti_[i]->SetLabel(mbti.substr(i, 1));
     descriptions_1_[i]->SetLabel(mbti_info.descriptions_1.at(i));
 
     if (i < 3) {
+      wxLogDebug(
+          _("MbtiInfoPanel::SetMbti() setting desc2: " + std::to_string(i)));
       descriptions_2_[i]->SetLabel(mbti_info.descriptions_2.at(i));
+      wxLogDebug("MbtiInfoPanel::SetMbti() 2");
     }
   }
 
+  wxLogDebug("MbtiInfoPanel::SetMbti() Setting wrap");
   for (size_t i = 0; i < 4; i++) {
     descriptions_1_[i]->Wrap(DESC_1_WRAP_PX);
     if (i < 3) {
@@ -41,6 +70,7 @@ void MbtiInfoPanel::SetMbti(std::string mbti) {
 
   this->Layout();
   this->Fit();
+  wxLogDebug("MbtiInfoPanel::SetMbti() END");
 }
 
 void MbtiInfoPanel::SetMbtiInfoData(std::shared_ptr<cpptoml::table> gui_state) {
@@ -92,14 +122,22 @@ struct MbtiInfoPanel::MbtiEntry MbtiInfoPanel::GetMbtiEntry(std::string key) {
   }
 
   struct MbtiInfoPanel::MbtiEntry error;
-  error.key = "Error";
+  error.key = "error";
+  error.desc1 = "error";
+  error.desc2 = "error";
 
-  wxLogWarning(_("Could not find mbti key " + key));
+  wxLogDebug(_("Could not find mbti key " + key));
   return error;
 }
 
 struct MbtiInfoPanel::MbtiInfo MbtiInfoPanel::GetMbtiInfo(std::string mbti) {
   wxLogDebug("MbtiInfoPanel::GetMbtiInfo() START");
+
+  if (mbti.length() != 4) {
+    wxLogDebug("MbtiInfoPanel::GetMbtiInfo(): Incorrect mbti str len");
+    wxLogWarning("MbtiInfoPanel::GetMbtiInfo(): Incorrect mbti str len");
+  }
+
   struct MbtiInfoPanel::MbtiInfo mbti_info;
 
   // Get description 1
@@ -110,81 +148,179 @@ struct MbtiInfoPanel::MbtiInfo MbtiInfoPanel::GetMbtiInfo(std::string mbti) {
     ss >> mbti_letter;
 
     struct MbtiEntry entry = GetMbtiEntry(mbti_letter);
-    mbti_info.descriptions_1.push_back(entry.desc1);
+
+    if (entry.key.compare("error") != 0) {
+      mbti_info.descriptions_1.push_back(entry.desc1);
+    } else {
+      mbti_info.descriptions_1.push_back("");
+    }
   }
 
   // First desc2
   struct MbtiEntry entry = GetMbtiEntry(mbti.substr(0, 1));
-  mbti_info.descriptions_2.push_back(entry.desc2);
+  if (entry.key.compare("error") != 0) {
+    mbti_info.descriptions_2.push_back(entry.desc2);
+  } else {
+    mbti_info.descriptions_2.push_back("");
+  }
 
   // Middle desc2
   std::string long_key = "";
   long_key = mbti.substr(1, 2);
   wxLogDebug(_(long_key));
 
+  bool found = false;
   for (size_t k = 0; k < mbti_entries_.size(); k++) {
     if (mbti_entries_.at(k).key.compare(long_key) == 0) {
       mbti_info.descriptions_2.push_back(mbti_entries_.at(k).desc2);
+      found = false;
       break;
     }
   }
 
-  // Last desc2
-  entry = GetMbtiEntry(mbti.substr(3, 1));
-  mbti_info.descriptions_2.push_back(entry.desc2);
-
-  if (mbti_info.descriptions_1.size() != 4 ||
-      mbti_info.descriptions_2.size() != 3) {
-    wxLogWarning(
-        "Could not parse MBTI info. Error on [mbti_info] (most likely)");
+  if (!found) {
+    mbti_info.descriptions_2.push_back("");
   }
 
+  // Last desc2
+  entry = GetMbtiEntry(mbti.substr(3, 1));
+  if (entry.key != "error") {
+    mbti_info.descriptions_2.push_back(entry.desc2);
+  } else {
+    mbti_info.descriptions_2.push_back("");
+  }
+
+  if (mbti_info.descriptions_1.size() != 4) {
+    wxLogDebug("mbti_info.descriptions_1.size() != 4");
+  }
+
+  if (mbti_info.descriptions_2.size() != 3) {
+    wxLogDebug("mbti_info.descriptions_2.size() != 3");
+  }
+
+  wxLogDebug("MbtiInfoPanel::GetMbtiInfo() END");
   return mbti_info;
+}
+
+std::vector<std::string> MbtiInfoPanel::GetMbtiAsVector() {
+  std::string mbti = GetMbti();
+  std::vector<std::string> result;
+
+  for (size_t i = 0; i < mbti.length(); i++) {
+    result.push_back(mbti.substr(i, 1));
+  }
+
+  return result;
+}
+
+std::string MbtiInfoPanel::GetMbti() {
+  std::string mbti_string = "";
+
+  // mbti
+  std::string mbti[4];
+  for (size_t i = 0; i < 4; i++) {
+    const int selection = choice_boxes_mbti_[i]->GetSelection();
+    if (selection != wxNOT_FOUND) {
+      const std::string value =
+          choice_boxes_mbti_[i]->GetString(selection).ToStdString();
+
+      mbti[i] = value;
+    } else {
+      mbti[i] = " ";
+    }
+    mbti_string += mbti[i];
+  }
+
+  return mbti_string;
+}
+
+void MbtiInfoPanel::OnMbtiChange(wxCommandEvent& event) {
+  std::string mbti = GetMbti();
+
+  if (mbti.length() == 4) {
+    SetMbti(mbti);
+  }
+
+  sizer_root_->Fit(this);
+}
+
+void MbtiInfoPanel::AddMbtiTuple(std::vector<wxArrayString>* source_vector,
+                                 std::string str1, std::string str2) {
+  wxArrayString tuple;
+  tuple.Add(str1);
+  tuple.Add(str2);
+  source_vector->push_back(tuple);
 }
 
 void MbtiInfoPanel::DoLayout() {
   sizer_ = new wxGridBagSizer(0, 0);
+  sizer_root_ = new wxStaticBoxSizer(wxVERTICAL, this, "MBTI");
+  wxWindow* parent_sizer = sizer_root_->GetStaticBox();
 
-  wxStaticLine* line1 = new wxStaticLine(this);
-  wxStaticLine* line2 = new wxStaticLine(this);
-  wxStaticLine* line3 = new wxStaticLine(this);
+  wxBoxSizer* sizer_mbti_combo_boxes = new wxBoxSizer(wxHORIZONTAL);
 
-  wxStaticText* mbti1 = new wxStaticText(this, wxID_ANY, wxEmptyString);
-  wxStaticText* mbti2 = new wxStaticText(this, wxID_ANY, wxEmptyString);
-  wxStaticText* mbti3 = new wxStaticText(this, wxID_ANY, wxEmptyString);
-  wxStaticText* mbti4 = new wxStaticText(this, wxID_ANY, wxEmptyString);
+  std::vector<wxArrayString> mbti_tuples;
 
-  wxStaticText* desc1 = new wxStaticText(this, wxID_ANY, wxEmptyString);
-  wxStaticText* desc2 = new wxStaticText(this, wxID_ANY, wxEmptyString);
-  wxStaticText* desc3 = new wxStaticText(this, wxID_ANY, wxEmptyString);
-  wxStaticText* desc4 = new wxStaticText(this, wxID_ANY, wxEmptyString);
+  AddMbtiTuple(&mbti_tuples, "I", "E");
+  AddMbtiTuple(&mbti_tuples, "S", "N");
+  AddMbtiTuple(&mbti_tuples, "T", "F");
+  AddMbtiTuple(&mbti_tuples, "J", "P");
 
-  wxStaticText* ext_desc1 = new wxStaticText(this, wxID_ANY, wxEmptyString);
-  wxStaticText* ext_desc2 = new wxStaticText(this, wxID_ANY, wxEmptyString);
-  wxStaticText* ext_desc3 = new wxStaticText(this, wxID_ANY, wxEmptyString);
+  for (size_t i = 0; i < 4; i++) {
+    choice_boxes_mbti_[i] =
+        new wxChoice(parent_sizer, wxID_ANY, wxDefaultPosition, wxSize(60, -1),
+                     mbti_tuples[i]);
+    sizer_mbti_combo_boxes->Add(choice_boxes_mbti_[i], 0, 0, 0);
+    sizer_mbti_combo_boxes->AddSpacer(5);
+    choice_boxes_mbti_[i]->Bind(wxEVT_CHOICE, &MbtiInfoPanel::OnMbtiChange,
+                                this);
+  }
+
+  sizer_root_->Add(sizer_mbti_combo_boxes, 0, wxALL, 6);
+
+  wxStaticLine* line1 = new wxStaticLine(parent_sizer);
+  wxStaticLine* line2 = new wxStaticLine(parent_sizer);
+  wxStaticLine* line3 = new wxStaticLine(parent_sizer);
+
+  wxStaticText* mbti1 = new wxStaticText(parent_sizer, wxID_ANY, wxEmptyString);
+  wxStaticText* mbti2 = new wxStaticText(parent_sizer, wxID_ANY, wxEmptyString);
+  wxStaticText* mbti3 = new wxStaticText(parent_sizer, wxID_ANY, wxEmptyString);
+  wxStaticText* mbti4 = new wxStaticText(parent_sizer, wxID_ANY, wxEmptyString);
+
+  wxStaticText* desc1 = new wxStaticText(parent_sizer, wxID_ANY, wxEmptyString);
+  wxStaticText* desc2 = new wxStaticText(parent_sizer, wxID_ANY, wxEmptyString);
+  wxStaticText* desc3 = new wxStaticText(parent_sizer, wxID_ANY, wxEmptyString);
+  wxStaticText* desc4 = new wxStaticText(parent_sizer, wxID_ANY, wxEmptyString);
+
+  wxStaticText* ext_desc1 =
+      new wxStaticText(parent_sizer, wxID_ANY, wxEmptyString);
+  wxStaticText* ext_desc2 =
+      new wxStaticText(parent_sizer, wxID_ANY, wxEmptyString);
+  wxStaticText* ext_desc3 =
+      new wxStaticText(parent_sizer, wxID_ANY, wxEmptyString);
 
   const int kFlags = wxALL | wxALIGN_CENTER;
   const int kBorder = 6;
 
-  sizer_->Add(line1, wxGBPosition(0, 0), wxGBSpan(1, 3), wxEXPAND, 0);
-  sizer_->Add(line2, wxGBPosition(2, 0), wxGBSpan(1, 3), wxEXPAND, 0);
-  sizer_->Add(line3, wxGBPosition(5, 0), wxGBSpan(1, 3), wxEXPAND, 0);
+  sizer_->Add(line1, wxGBPosition(1, 0), wxGBSpan(1, 3), wxEXPAND, 0);
+  sizer_->Add(line2, wxGBPosition(3, 0), wxGBSpan(1, 3), wxEXPAND, 0);
+  sizer_->Add(line3, wxGBPosition(6, 0), wxGBSpan(1, 3), wxEXPAND, 0);
 
-  sizer_->Add(mbti1, wxGBPosition(1, 0), wxGBSpan(1, 1), kFlags, kBorder);
-  sizer_->Add(mbti2, wxGBPosition(3, 0), wxGBSpan(1, 1), kFlags, kBorder);
-  sizer_->Add(mbti3, wxGBPosition(4, 0), wxGBSpan(1, 1), kFlags, kBorder);
-  sizer_->Add(mbti4, wxGBPosition(6, 0), wxGBSpan(1, 1), kFlags, kBorder);
+  sizer_->Add(mbti1, wxGBPosition(2, 0), wxGBSpan(1, 1), kFlags, kBorder);
+  sizer_->Add(mbti2, wxGBPosition(4, 0), wxGBSpan(1, 1), kFlags, kBorder);
+  sizer_->Add(mbti3, wxGBPosition(5, 0), wxGBSpan(1, 1), kFlags, kBorder);
+  sizer_->Add(mbti4, wxGBPosition(7, 0), wxGBSpan(1, 1), kFlags, kBorder);
 
   const int kDescFlags = wxALL | wxALIGN_LEFT;
   const int kDescBorder = 6;
 
-  sizer_->Add(desc1, wxGBPosition(1, 1), wxGBSpan(1, 1), kDescFlags,
+  sizer_->Add(desc1, wxGBPosition(2, 1), wxGBSpan(1, 1), kDescFlags,
               kDescBorder);
-  sizer_->Add(desc2, wxGBPosition(3, 1), wxGBSpan(1, 1), kDescFlags,
+  sizer_->Add(desc2, wxGBPosition(4, 1), wxGBSpan(1, 1), kDescFlags,
               kDescBorder);
-  sizer_->Add(desc3, wxGBPosition(4, 1), wxGBSpan(1, 1), kDescFlags,
+  sizer_->Add(desc3, wxGBPosition(5, 1), wxGBSpan(1, 1), kDescFlags,
               kDescBorder);
-  sizer_->Add(desc4, wxGBPosition(6, 1), wxGBSpan(1, 1), kDescFlags,
+  sizer_->Add(desc4, wxGBPosition(7, 1), wxGBSpan(1, 1), kDescFlags,
               kDescBorder);
 
   labels_mbti_[0] = mbti1;
@@ -208,11 +344,12 @@ void MbtiInfoPanel::DoLayout() {
   descriptions_2_[1] = ext_desc2;
   descriptions_2_[2] = ext_desc3;
 
-  sizer_->Add(ext_desc1, wxGBPosition(1, 2), wxGBSpan(1, 1), wxLEFT, 20);
-  sizer_->Add(ext_desc2, wxGBPosition(3, 2), wxGBSpan(2, 1), wxLEFT, 20);
-  sizer_->Add(ext_desc3, wxGBPosition(6, 2), wxGBSpan(1, 1), wxLEFT, 20);
+  sizer_->Add(ext_desc1, wxGBPosition(2, 2), wxGBSpan(1, 1), wxLEFT, 20);
+  sizer_->Add(ext_desc2, wxGBPosition(4, 2), wxGBSpan(2, 1), wxLEFT, 20);
+  sizer_->Add(ext_desc3, wxGBPosition(7, 2), wxGBSpan(1, 1), wxLEFT, 20);
 
-  this->SetSizer(sizer_);
+  sizer_root_->Add(sizer_, 0, wxALL, 6);
+  this->SetSizer(sizer_root_);
 
   Layout();
 }

--- a/src/components/mbti_info_panel.cpp
+++ b/src/components/mbti_info_panel.cpp
@@ -1,2 +1,12 @@
 #include "mbti_info_panel.hpp"
 
+#include <memory>
+#include <string>
+#include <vector>
+
+MbtiInfoPanel::MbtiInfoPanel(wxWindow* parent, wxWindowID id,
+                             const wxPoint& pos, const wxSize& size,
+                             int64_t style)
+    : wxPanel(parent, id, pos, size, style) {
+  DoLayout();
+}

--- a/src/components/mbti_info_panel.cpp
+++ b/src/components/mbti_info_panel.cpp
@@ -173,7 +173,7 @@ struct MbtiInfoPanel::MbtiInfo MbtiInfoPanel::GetMbtiInfo(std::string mbti) {
   for (size_t k = 0; k < mbti_entries_.size(); k++) {
     if (mbti_entries_.at(k).key.compare(long_key) == 0) {
       mbti_info.descriptions_2.push_back(mbti_entries_.at(k).desc2);
-      found = false;
+      found = true;
       break;
     }
   }
@@ -234,6 +234,16 @@ std::string MbtiInfoPanel::GetMbti() {
   return mbti_string;
 }
 
+void MbtiInfoPanel::HideMbtiSelection() {
+  sizer_root_->Hide(sizer_mbti_combo_boxes_, true);
+
+  for (size_t i = 0; i < 4; i++) {
+    choice_boxes_mbti_[i]->Hide();
+  }
+
+  this->Layout();
+}
+
 void MbtiInfoPanel::OnMbtiChange(wxCommandEvent& event) {
   std::string mbti = GetMbti();
 
@@ -258,7 +268,7 @@ void MbtiInfoPanel::DoLayout() {
   sizer_root_ = new wxStaticBoxSizer(wxVERTICAL, this, "MBTI");
   wxWindow* parent_sizer = sizer_root_->GetStaticBox();
 
-  wxBoxSizer* sizer_mbti_combo_boxes = new wxBoxSizer(wxHORIZONTAL);
+  sizer_mbti_combo_boxes_ = new wxBoxSizer(wxHORIZONTAL);
 
   std::vector<wxArrayString> mbti_tuples;
 
@@ -271,13 +281,13 @@ void MbtiInfoPanel::DoLayout() {
     choice_boxes_mbti_[i] =
         new wxChoice(parent_sizer, wxID_ANY, wxDefaultPosition, wxSize(60, -1),
                      mbti_tuples[i]);
-    sizer_mbti_combo_boxes->Add(choice_boxes_mbti_[i], 0, 0, 0);
-    sizer_mbti_combo_boxes->AddSpacer(5);
+    sizer_mbti_combo_boxes_->Add(choice_boxes_mbti_[i], 0, 0, 0);
+    sizer_mbti_combo_boxes_->AddSpacer(5);
     choice_boxes_mbti_[i]->Bind(wxEVT_CHOICE, &MbtiInfoPanel::OnMbtiChange,
                                 this);
   }
 
-  sizer_root_->Add(sizer_mbti_combo_boxes, 0, wxALL, 6);
+  sizer_root_->Add(sizer_mbti_combo_boxes_, 0, wxALL, 6);
 
   wxStaticLine* line1 = new wxStaticLine(parent_sizer);
   wxStaticLine* line2 = new wxStaticLine(parent_sizer);
@@ -303,25 +313,25 @@ void MbtiInfoPanel::DoLayout() {
   const int kFlags = wxALL | wxALIGN_CENTER;
   const int kBorder = 6;
 
-  sizer_->Add(line1, wxGBPosition(1, 0), wxGBSpan(1, 3), wxEXPAND, 0);
-  sizer_->Add(line2, wxGBPosition(3, 0), wxGBSpan(1, 3), wxEXPAND, 0);
-  sizer_->Add(line3, wxGBPosition(6, 0), wxGBSpan(1, 3), wxEXPAND, 0);
+  sizer_->Add(line1, wxGBPosition(0, 0), wxGBSpan(1, 3), wxEXPAND, 0);
+  sizer_->Add(line2, wxGBPosition(2, 0), wxGBSpan(1, 3), wxEXPAND, 0);
+  sizer_->Add(line3, wxGBPosition(5, 0), wxGBSpan(1, 3), wxEXPAND, 0);
 
-  sizer_->Add(mbti1, wxGBPosition(2, 0), wxGBSpan(1, 1), kFlags, kBorder);
-  sizer_->Add(mbti2, wxGBPosition(4, 0), wxGBSpan(1, 1), kFlags, kBorder);
-  sizer_->Add(mbti3, wxGBPosition(5, 0), wxGBSpan(1, 1), kFlags, kBorder);
-  sizer_->Add(mbti4, wxGBPosition(7, 0), wxGBSpan(1, 1), kFlags, kBorder);
+  sizer_->Add(mbti1, wxGBPosition(1, 0), wxGBSpan(1, 1), kFlags, kBorder);
+  sizer_->Add(mbti2, wxGBPosition(3, 0), wxGBSpan(1, 1), kFlags, kBorder);
+  sizer_->Add(mbti3, wxGBPosition(4, 0), wxGBSpan(1, 1), kFlags, kBorder);
+  sizer_->Add(mbti4, wxGBPosition(6, 0), wxGBSpan(1, 1), kFlags, kBorder);
 
   const int kDescFlags = wxALL | wxALIGN_LEFT;
   const int kDescBorder = 6;
 
-  sizer_->Add(desc1, wxGBPosition(2, 1), wxGBSpan(1, 1), kDescFlags,
+  sizer_->Add(desc1, wxGBPosition(1, 1), wxGBSpan(1, 1), kDescFlags,
               kDescBorder);
-  sizer_->Add(desc2, wxGBPosition(4, 1), wxGBSpan(1, 1), kDescFlags,
+  sizer_->Add(desc2, wxGBPosition(3, 1), wxGBSpan(1, 1), kDescFlags,
               kDescBorder);
-  sizer_->Add(desc3, wxGBPosition(5, 1), wxGBSpan(1, 1), kDescFlags,
+  sizer_->Add(desc3, wxGBPosition(4, 1), wxGBSpan(1, 1), kDescFlags,
               kDescBorder);
-  sizer_->Add(desc4, wxGBPosition(7, 1), wxGBSpan(1, 1), kDescFlags,
+  sizer_->Add(desc4, wxGBPosition(6, 1), wxGBSpan(1, 1), kDescFlags,
               kDescBorder);
 
   labels_mbti_[0] = mbti1;
@@ -345,9 +355,9 @@ void MbtiInfoPanel::DoLayout() {
   descriptions_2_[1] = ext_desc2;
   descriptions_2_[2] = ext_desc3;
 
-  sizer_->Add(ext_desc1, wxGBPosition(2, 2), wxGBSpan(1, 1), wxLEFT, 20);
-  sizer_->Add(ext_desc2, wxGBPosition(4, 2), wxGBSpan(2, 1), wxLEFT, 20);
-  sizer_->Add(ext_desc3, wxGBPosition(7, 2), wxGBSpan(1, 1), wxLEFT, 20);
+  sizer_->Add(ext_desc1, wxGBPosition(1, 2), wxGBSpan(1, 1), wxLEFT, 20);
+  sizer_->Add(ext_desc2, wxGBPosition(3, 2), wxGBSpan(2, 1), wxLEFT, 20);
+  sizer_->Add(ext_desc3, wxGBPosition(6, 2), wxGBSpan(1, 1), wxLEFT, 20);
 
   sizer_root_->Add(sizer_, 0, wxALL, 6);
   this->SetSizer(sizer_root_);

--- a/src/components/mbti_info_panel.hpp
+++ b/src/components/mbti_info_panel.hpp
@@ -1,0 +1,37 @@
+#ifndef COMPONENTS_MBTI_INFO_HPP_
+#define COMPONENTS_MBTI_INFO_HPP_
+
+#include <wx/wxprec.h>
+#ifndef WX_PRECOMP
+#include <wx/wx.h>
+#endif
+
+#include "include/cpptoml.h"
+
+class MbtiInfoPanel : public wxPanel {
+ public:
+  MbtiInfoPanel(wxWindow* parent, wxWindowID id,
+                const wxPoint& pos = wxDefaultPosition,
+                const wxSize& size = wxDefaultSize, int64_t style = 0);
+  ~MbtiInfoPanel(){};
+
+  /**
+   * Example: SetMbti("ISTJ");
+   */
+  void SetMbti(std::string mbti);
+
+  /**
+   * TOML SPEC:
+   * [mbti_info]
+   *   [[mbti_info.type]]
+   *     key = "I"
+   *     description_1 = ""
+   *     description_2 = ""
+   *
+   * Where description_1 will always exist.
+   * description_2 is optional.
+   */
+  void SetMbtiInfoData(std::shared_ptr<cpptoml::table>(gui_state));
+};
+
+#endif  // COMPONENTS_MBTI_INFO_HPP_

--- a/src/components/mbti_info_panel.hpp
+++ b/src/components/mbti_info_panel.hpp
@@ -65,6 +65,7 @@ class MbtiInfoPanel : public wxPanel {
   wxStaticText* labels_mbti_[4];
   wxStaticText* descriptions_1_[4];
   wxStaticText* descriptions_2_[3];
+  wxGridBagSizer* sizer_ = NULL;
 };
 
 #endif  // COMPONENTS_MBTI_INFO_HPP_

--- a/src/components/mbti_info_panel.hpp
+++ b/src/components/mbti_info_panel.hpp
@@ -9,9 +9,9 @@
 #include <wx/gbsizer.h>
 #include <wx/statline.h>
 
+#include <memory>
 #include <sstream>
 #include <string>
-#include <memory>
 #include <vector>
 
 #include "include/cpptoml.h"
@@ -57,8 +57,12 @@ class MbtiInfoPanel : public wxPanel {
    */
   void SetMbtiInfoData(std::shared_ptr<cpptoml::table>(gui_state));
   struct MbtiInfoPanel::MbtiEntry GetMbtiEntry(std::string key);
+  std::vector<std::string> GetMbtiAsVector();
+  std::string GetMbti();
+  void SetMbti(std::vector<std::string> mbti);
 
  private:
+  void OnMbtiChange(wxCommandEvent& event);  // NOLINT
   void DoLayout();
   std::string mbti_;
   std::vector<struct MbtiEntry> mbti_entries_;
@@ -66,6 +70,10 @@ class MbtiInfoPanel : public wxPanel {
   wxStaticText* descriptions_1_[4];
   wxStaticText* descriptions_2_[3];
   wxGridBagSizer* sizer_ = NULL;
+  wxChoice* choice_boxes_mbti_[4];
+  wxStaticBoxSizer* sizer_root_ = NULL;
+  void AddMbtiTuple(std::vector<wxArrayString>* source_vector, std::string str1,
+                    std::string str2);
 };
 
 #endif  // COMPONENTS_MBTI_INFO_HPP_

--- a/src/components/mbti_info_panel.hpp
+++ b/src/components/mbti_info_panel.hpp
@@ -6,7 +6,18 @@
 #include <wx/wx.h>
 #endif
 
+#include <wx/gbsizer.h>
+#include <wx/statline.h>
+
+#include <sstream>
+#include <string>
+#include <memory>
+#include <vector>
+
 #include "include/cpptoml.h"
+
+#define DESC_1_WRAP_PX 300
+#define DESC_2_WRAP_PX 300
 
 class MbtiInfoPanel : public wxPanel {
  public:
@@ -14,6 +25,19 @@ class MbtiInfoPanel : public wxPanel {
                 const wxPoint& pos = wxDefaultPosition,
                 const wxSize& size = wxDefaultSize, int64_t style = 0);
   ~MbtiInfoPanel(){};
+
+  struct MbtiInfo {
+    std::vector<std::string> descriptions_1;
+    std::vector<std::string> descriptions_2;
+  };
+
+  struct MbtiEntry {
+    std::string key;
+    std::string desc1;
+    std::string desc2;
+  };
+
+  struct MbtiInfo GetMbtiInfo(std::string mbti);
 
   /**
    * Example: SetMbti("ISTJ");
@@ -32,6 +56,15 @@ class MbtiInfoPanel : public wxPanel {
    * description_2 is optional.
    */
   void SetMbtiInfoData(std::shared_ptr<cpptoml::table>(gui_state));
+  struct MbtiInfoPanel::MbtiEntry GetMbtiEntry(std::string key);
+
+ private:
+  void DoLayout();
+  std::string mbti_;
+  std::vector<struct MbtiEntry> mbti_entries_;
+  wxStaticText* labels_mbti_[4];
+  wxStaticText* descriptions_1_[4];
+  wxStaticText* descriptions_2_[3];
 };
 
 #endif  // COMPONENTS_MBTI_INFO_HPP_

--- a/src/components/mbti_info_panel.hpp
+++ b/src/components/mbti_info_panel.hpp
@@ -60,6 +60,7 @@ class MbtiInfoPanel : public wxPanel {
   std::vector<std::string> GetMbtiAsVector();
   std::string GetMbti();
   void SetMbti(std::vector<std::string> mbti);
+  void HideMbtiSelection();
 
  private:
   void OnMbtiChange(wxCommandEvent& event);  // NOLINT
@@ -74,6 +75,7 @@ class MbtiInfoPanel : public wxPanel {
   wxStaticBoxSizer* sizer_root_ = NULL;
   void AddMbtiTuple(std::vector<wxArrayString>* source_vector, std::string str1,
                     std::string str2);
+  wxBoxSizer* sizer_mbti_combo_boxes_ = NULL;
 };
 
 #endif  // COMPONENTS_MBTI_INFO_HPP_

--- a/src/data_manager.hpp
+++ b/src/data_manager.hpp
@@ -89,6 +89,8 @@ class DataManager {
 
   DataManager::PanelId GetIdFromName(std::string name);
 
+  DataPanel* panels_[PanelId::kPanelCount];
+
  private:
   /**
    * Reads the user and gui config and initializes each panel
@@ -107,7 +109,6 @@ class DataManager {
    */
   void AddPanel(DataPanel* panel, PanelId id);
 
-  DataPanel* panels_[PanelId::kPanelCount];
   DataManager::PanelId ids_[PanelId::kPanelCount];
 
   wxWindow* main_frame_ = NULL;

--- a/src/data_panel.cpp
+++ b/src/data_panel.cpp
@@ -12,6 +12,7 @@ DataPanel::DataPanel(wxWindow* parent, wxWindowID id, std::string panel_name,
   panel_title_ = panel_title;
 
   DataPanel::panels_.push_back(this);
+  this->Bind(wxEVT_SIZE, &DataPanel::OnSizeChange, this);
 }
 
 std::string DataPanel::GetPanelName() { return panel_name_; }
@@ -22,6 +23,11 @@ bool DataPanel::Next() { return false; }
 
 void DataPanel::OnTabActivate() {
   wxLogDebug(_("OnTabActivate not implemented for ") + _(this->GetPanelName()));
+}
+
+void DataPanel::OnSizeChange(wxSizeEvent& event) {
+  wxLogDebug("Changed panel size event");
+  // this->SetScrollRate(10, 10);
 }
 
 DataPanel* DataPanel::GetPanelByName(std::string panel_name) {

--- a/src/data_panel.hpp
+++ b/src/data_panel.hpp
@@ -66,6 +66,7 @@ class DataPanel : public wxScrolled<wxPanel> {
  protected:
   std::string panel_name_;
   std::string panel_title_;
+  void OnSizeChange(wxSizeEvent& event);  // NOLINT
 };
 
 #endif  // DATA_PANEL_HPP_

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -49,6 +49,11 @@ MainFrame::MainFrame(wxWindow* parent, wxWindowID id, const wxString& title,
 
   SetSize(minSize);
 
+  // Add scrol bars?
+  for (size_t i = 0; i < DataManager::kPanelCount; i++) {
+    data_manager_->panels_[i]->SetScrollRate(10, 10);
+  }
+
   this->Bind(wxEVT_SIZE, &MainFrame::OnSizeChange, this);
 }
 

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -38,18 +38,18 @@ MainFrame::MainFrame(wxWindow* parent, wxWindowID id, const wxString& title,
   DoLayout();
   Fit();
 
-  wxSize minSize = GetOverallMinSize();
+  wxSize min_size = GetOverallMinSize();
 
   // To fix scroll bars on theme analysis panel
-  minSize.IncBy(10, 10);
+  min_size.IncBy(10, 10);
 
   // We want to be able to make smaller than the giant
   // analysis panel, so this is temporarily disabled
   // SetMinSize(minSize);
 
-  SetSize(minSize);
+  SetSize(min_size);
 
-  // Add scrol bars?
+  // Add scrol bars
   for (size_t i = 0; i < DataManager::kPanelCount; i++) {
     data_manager_->panels_[i]->SetScrollRate(10, 10);
   }
@@ -110,6 +110,8 @@ void MainFrame::OnNotebookSelectionChange(wxBookCtrlEvent& event) {
 
     if (panel) {
       panel->OnTabActivate();
+      active_panel_name_ = panel->GetPanelName();
+      wxLogDebug(_(active_panel_name_));
     }
   }
 
@@ -140,10 +142,12 @@ bool MainFrame::DisplayNextPanel() {
   return false;
 }
 
+// NOTE: Modified to only return size with Analysis tab
 wxSize MainFrame::GetOverallMinSize() {
   Freeze();
   wxLogDebug(_("Getting best size..."));
   wxSize minSize = GetSize();
+  wxSize theme_size = GetSize();
 
   wxLogDebug(_(std::to_string(minSize.x)) + _(", ") +
              _(std::to_string(minSize.y)));
@@ -161,6 +165,10 @@ wxSize MainFrame::GetOverallMinSize() {
     if (tmpSize.y > minSize.y) {
       minSize.y = tmpSize.y;
     }
+
+    if (active_panel_name_.compare("theme_analysis") == 0) {
+      theme_size = GetSize();
+    }
   }
 
   wxLogDebug(_("Best size = ") + _(std::to_string(minSize.x)) + _(", ") +
@@ -170,12 +178,21 @@ wxSize MainFrame::GetOverallMinSize() {
   notebook_assessments_->SetSelection(0);
 
   Thaw();
-  return minSize;
+  return theme_size;
+}
+
+void MainFrame::TriggerRefresh() {
+  wxSize s = this->GetSize();
+  wxLogDebug(_(std::to_string(s.GetX()) + ", " + std::to_string(s.GetY())));
+  panel_main_->SetSize(GetClientSize());
+  this->FitInside();
 }
 
 void MainFrame::OnSizeChange(wxSizeEvent& event) {
   wxLogDebug("Resize MainFrame");
 
+  wxSize s = this->GetSize();
+  wxLogDebug(_(std::to_string(s.GetX()) + ", " + std::to_string(s.GetY())));
   panel_main_->SetSize(GetClientSize());
   this->FitInside();
 }

--- a/src/main_frame.hpp
+++ b/src/main_frame.hpp
@@ -34,6 +34,8 @@ class MainFrame : public wxFrame {
    */
   wxSize GetOverallMinSize();
 
+  void TriggerRefresh();
+
  private:
   void DoLayout();
   void OnSizeChange(wxSizeEvent& event);                   // NOLINT
@@ -46,6 +48,7 @@ class MainFrame : public wxFrame {
   wxFlexGridSizer* sizer_content_ = NULL;
   wxPanel* panel_main_ = NULL;
   bool exit_requested_ = false;
+  std::string active_panel_name_ = "";
 
   /**
    * [0][i] - Top notebook

--- a/src/panels/details_panel.hpp
+++ b/src/panels/details_panel.hpp
@@ -14,6 +14,7 @@
 #include <string>
 
 #include "src/data_panel.hpp"
+#include "src/components/mbti_info_panel.hpp"
 
 class DetailsPanel : public DataPanel {
  public:

--- a/src/panels/details_panel.hpp
+++ b/src/panels/details_panel.hpp
@@ -13,8 +13,8 @@
 #include <memory>
 #include <string>
 
-#include "src/data_panel.hpp"
 #include "src/components/mbti_info_panel.hpp"
+#include "src/data_panel.hpp"
 
 class DetailsPanel : public DataPanel {
  public:

--- a/src/panels/external_panel.cpp
+++ b/src/panels/external_panel.cpp
@@ -146,21 +146,22 @@ void ExternalPanel::DoLayout() {
   wxFlexGridSizer* sizer_content = new wxFlexGridSizer(2, 2, 30, 30);
 
   wxBoxSizer* sizer_left_col = new wxBoxSizer(wxVERTICAL);
-  wxBoxSizer* sizer_career = new wxBoxSizer(wxVERTICAL);
+  wxBoxSizer* sizer_right_col = new wxBoxSizer(wxVERTICAL);
 
   panel_life_keys_info_ = new LifeKeysInfoPanel(this, wxID_ANY);
 
   panel_career_ =
       new CareerTestPanel(this, wxID_ANY, "career_test", "Career Test");
-  sizer_career->Add(panel_career_, 0, wxEXPAND | wxALL, 5);
 
   mbti_info_panel_ = new MbtiInfoPanel(this, wxID_ANY);
 
-  sizer_left_col->Add(mbti_info_panel_, 0, wxBOTTOM, 20);
-  sizer_left_col->Add(panel_life_keys_info_, 0, wxALL, 0);
+  sizer_left_col->Add(mbti_info_panel_, 0, wxBOTTOM, 12);
+  sizer_left_col->Add(panel_career_, 0, wxALL | wxALIGN_CENTER, 0);
 
-  sizer_content->Add(sizer_left_col, 0, wxALL, 5);
-  sizer_content->Add(sizer_career, 0, wxALL, 5);
+  sizer_right_col->Add(panel_life_keys_info_, 0, wxALL, 0);
+
+  sizer_content->Add(sizer_left_col, 0, wxALL, 6);
+  sizer_content->Add(sizer_right_col, 0, wxALL, 6);
 
   sizer->Add(0, 0, 0, 0);
   sizer->Add(sizer_content, 0, 0, 0);

--- a/src/panels/external_panel.cpp
+++ b/src/panels/external_panel.cpp
@@ -274,7 +274,9 @@ void ExternalPanel::OnMbtiChange(wxCommandEvent& event) {
 }
 
 void ExternalPanel::DoLayout() {
-  wxGridSizer* sizer = new wxGridSizer(1, 2, 0, 0);
+  wxFlexGridSizer* sizer = new wxFlexGridSizer(1, 3, 0, 0);
+  wxFlexGridSizer* sizer_content = new wxFlexGridSizer(2, 2, 30, 30);
+
   wxBoxSizer* sizer_mbti_keys = new wxBoxSizer(wxVERTICAL);
   wxStaticBoxSizer* sizer_mbti = new wxStaticBoxSizer(wxVERTICAL, this, "MBTI");
   wxBoxSizer* sizer_mbti_combo_boxes = new wxBoxSizer(wxHORIZONTAL);
@@ -310,8 +312,15 @@ void ExternalPanel::DoLayout() {
   sizer_mbti_keys->Add(sizer_mbti, 0, wxBOTTOM, 20);
   sizer_mbti_keys->Add(sizer_keys_, 0, wxALL, 0);
 
-  sizer->Add(sizer_mbti_keys, 0, wxALL, 5);
-  sizer->Add(sizer_career, 0, wxALL, 5);
+  sizer_content->Add(sizer_mbti_keys, 0, wxALL, 5);
+  sizer_content->Add(sizer_career, 0, wxALL, 5);
+
+  sizer->Add(0, 0, 0, 0);
+  sizer->Add(sizer_content, 0, 0, 0);
+  sizer->Add(0, 0, 0, 0);
+
+  sizer->AddGrowableCol(0);
+  sizer->AddGrowableCol(1);
 
   Layout();
   this->SetSizer(sizer);

--- a/src/panels/external_panel.hpp
+++ b/src/panels/external_panel.hpp
@@ -68,10 +68,10 @@ class ExternalPanel : public DataPanel {
   void DoLayout();
   void AddMbtiTuple(std::vector<wxArrayString>* source_vector, std::string str1,
                     std::string str2);
-  wxChoice* choice_boxes_mbti_[4];
+  wxChoice* choice_boxes_mbti__[4];
   CareerTestPanel* panel_career_ = NULL;
   MbtiInfoPanel* mbti_info_panel_ = NULL;
   LifeKeysInfoPanel* panel_life_keys_info_ = NULL;
-  wxStaticBoxSizer* sizer_mbti_ = NULL;
+  wxStaticBoxSizer* sizer_mbti__ = NULL;
 };
 #endif  // PANELS_EXTERNAL_PANEL_HPP_

--- a/src/panels/external_panel.hpp
+++ b/src/panels/external_panel.hpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "src/career_test_panel.hpp"
+#include "src/components/mbti_info_panel.hpp"
 #include "src/data_panel.hpp"
 
 #define CHOICE_BOX_KEYS_COUNT 3
@@ -62,6 +63,7 @@ class ExternalPanel : public DataPanel {
   std::string GetMbti();
 
  private:
+  void OnMbtiChange(wxCommandEvent& event);  // NOLINT
   void DoLayout();
   void AddMbtiTuple(std::vector<wxArrayString>* source_vector, std::string str1,
                     std::string str2);
@@ -69,5 +71,6 @@ class ExternalPanel : public DataPanel {
   wxChoice* choice_boxes_keys_[CHOICE_BOX_KEYS_COUNT];
   wxChoice* choice_boxes_mbti_[4];
   CareerTestPanel* panel_career_ = NULL;
+  MbtiInfoPanel* mbti_info_panel_ = NULL;
 };
 #endif  // PANELS_EXTERNAL_PANEL_HPP_

--- a/src/panels/external_panel.hpp
+++ b/src/panels/external_panel.hpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "src/career_test_panel.hpp"
+#include "src/components/life_keys_info_panel.hpp"
 #include "src/components/mbti_info_panel.hpp"
 #include "src/data_panel.hpp"
 
@@ -67,10 +68,10 @@ class ExternalPanel : public DataPanel {
   void DoLayout();
   void AddMbtiTuple(std::vector<wxArrayString>* source_vector, std::string str1,
                     std::string str2);
-  wxBoxSizer* sizer_keys_ = NULL;
-  wxChoice* choice_boxes_keys_[CHOICE_BOX_KEYS_COUNT];
   wxChoice* choice_boxes_mbti_[4];
   CareerTestPanel* panel_career_ = NULL;
   MbtiInfoPanel* mbti_info_panel_ = NULL;
+  LifeKeysInfoPanel* panel_life_keys_info_ = NULL;
+  wxStaticBoxSizer* sizer_mbti_ = NULL;
 };
 #endif  // PANELS_EXTERNAL_PANEL_HPP_

--- a/src/panels/theme_analysis_panel.cpp
+++ b/src/panels/theme_analysis_panel.cpp
@@ -46,7 +46,8 @@ void ThemeAnalysisPanel::OnSizeChange(wxSizeEvent& event) {
 }
 
 bool ThemeAnalysisPanel::SetGuiState(std::shared_ptr<cpptoml::table> state) {
-  return false;
+  panel_mbti_info_->SetMbtiInfoData(state);
+  return true;
 }
 
 std::shared_ptr<cpptoml::table> ThemeAnalysisPanel::GetUserState() {
@@ -159,12 +160,7 @@ void ThemeAnalysisPanel::OnTabActivate() {
   BindButtons(priorities_);
 
   std::string mbti = external_panel->GetMbti();
-
-  if (mbti.length() == 0) {
-    mbti = "        ";
-  }
-
-  label_mbti_->SetLabel(mbti);
+  panel_mbti_info_->SetMbti(mbti);
 
   Layout();
   this->FitInside();
@@ -303,26 +299,6 @@ wxBoxSizer* ThemeAnalysisPanel::CreateThemePanels() {
   return sizer_themes;
 }
 
-wxPanel* ThemeAnalysisPanel::CreateMbtiPanel() {
-  wxPanel* panel = new wxPanel(this, wxID_ANY);
-  panel->SetMinSize(wxSize(50, -1));
-  wxStaticBoxSizer* sizer = new wxStaticBoxSizer(wxHORIZONTAL, panel, "MBTI");
-
-  ExternalPanel* external_panel =
-      static_cast<ExternalPanel*>(GetPanelByName("external"));
-  std::string mbti = external_panel->GetMbti();
-
-  if (mbti.length() != 4) {
-    mbti = "        ";
-  }
-
-  label_mbti_ = new wxStaticText(sizer->GetStaticBox(), wxID_ANY, mbti);
-  sizer->Add(label_mbti_, 0, wxALIGN_CENTER | wxALL, 5);
-  panel->SetSizer(sizer);
-
-  return panel;
-}
-
 void ThemeAnalysisPanel::DoLayout() {
   wxFlexGridSizer* sizer_main = new wxFlexGridSizer(1, 5, 0, 0);
   wxBoxSizer* sizer_left = new wxBoxSizer(wxVERTICAL);
@@ -357,13 +333,14 @@ void ThemeAnalysisPanel::DoLayout() {
   wxBoxSizer* sizer_themes = CreateThemePanels();
 
   wxStaticBoxSizer* sizer_colours = CreateColourSelection();
-  wxPanel* panel_mbti = CreateMbtiPanel();
+  panel_mbti_info_ = new MbtiInfoPanel(this, wxID_ANY);
+  panel_mbti_info_->HideMbtiSelection();
 
   const int flags = wxALL;
   const int border = 5;
 
   // sizer_mbti_colour
-  sizer_mbti_colour->Add(panel_mbti, 0, flags, border);
+  sizer_mbti_colour->Add(panel_mbti_info_, 0, flags, border);
   sizer_mbti_colour->Add(sizer_colours, 0, flags, border);
 
   // sizer_boxes_left

--- a/src/panels/theme_analysis_panel.hpp
+++ b/src/panels/theme_analysis_panel.hpp
@@ -13,6 +13,7 @@
 #include "src/checkbox_panel.hpp"
 #include "src/coloured_button.hpp"
 #include "src/coloured_button_container.hpp"
+#include "src/components/mbti_info_panel.hpp"
 #include "src/data_panel.hpp"
 #include "src/panels/external_panel.hpp"
 #include "src/panels/priorities_panel.hpp"
@@ -63,7 +64,6 @@ class ThemeAnalysisPanel : public DataPanel {
   void UnbindButtons(ColouredButtonContainer* container);
   wxStaticBoxSizer* CreateColourSelection();
   wxBoxSizer* CreateThemePanels();
-  wxPanel* CreateMbtiPanel();
   wxPanel* CreateQuestionDisplay(std::string source_panel_name,
                                  std::string panel_title);
   /**
@@ -107,6 +107,7 @@ class ThemeAnalysisPanel : public DataPanel {
   int active_colour_index_ = 0;
   wxPanel* panel_colour_preview_ = NULL;
   wxStaticText* label_mbti_ = NULL;
+  MbtiInfoPanel* panel_mbti_info_ = NULL;
 };
 
 #endif  // PANELS_THEME_ANALYSIS_PANEL_HPP_


### PR DESCRIPTION
Sorry I got confused initially so this pull request contains two major features. Please Squash the PR.

### Added
- Display life key information on External Panel (closes #137)
- Display MBTI Info on External panel and Themes panel (closes #136)
- Scroll bars for panels that are larger than the MainFrame

### Changed
- Float external panel

### Screenshots
![mbti_1](https://user-images.githubusercontent.com/5778739/35381865-4547e3f6-01c6-11e8-904d-8be4c6b5f43e.png)
![mbti_2](https://user-images.githubusercontent.com/5778739/35381866-458a079a-01c6-11e8-84ee-e4d4b1cd5203.png)
![mbti_3](https://user-images.githubusercontent.com/5778739/35381869-45cac5d2-01c6-11e8-93bd-f8bc7c0c6f7d.png)
![mbti_4](https://user-images.githubusercontent.com/5778739/35381871-460b60f6-01c6-11e8-8773-34755dd7d73c.png)
